### PR TITLE
fix(correction): 1.6.5 D — an own-artifact qa repair can reach a fill (#970, #969)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ All notable changes to SquadOps are recorded here. Format loosely follows
   `config_overrides: {max_completion_tokens: 12288}`; four of ten qa primary emissions in that
   set sat at or within 3% of the 8,192 cap. The registry clamp (the V38 pin) and the dev
   budget are untouched. Changes `resolved_config_hash`; measured by prediction Q5.
+- **D — an own-artifact qa repair can reach a fill** (#970, with #969's brief). Under fill mode
+  the shells are merge products, never in `expected_artifacts`, so the own-artifact repair aimed
+  at the plan's declared file and a failing fill was structurally unreachable. Now: the target is
+  the failing slot's shell, read from the scaffold evidence's fill-layer observations; the repair
+  authors under the **same** fill-mode brief as `qa.test` (one composition seam,
+  `fill_mode_brief`, plus a repair addendum naming the failed slots with the runner's reason);
+  it emits fill blocks, and the handler recovers every other slot's fill from the task's current
+  shells, folds the repair's fills in, passes the same merge gate (#1087, #1094) and emits the
+  merged shell at the shell path, so the patch overlay supersedes the failed one and the retest
+  runs it. Round-trip pinned: recovering the fills from a merged shell and re-merging reproduces
+  it byte for byte. Measured by prediction Q4.
 
 ## [1.6.4] — 2026-08-26
 

--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -280,6 +280,61 @@ def _probe_owned_slots(failure_evidence: Any, failed_inputs: dict[str, Any]) -> 
     return slots
 
 
+def _fill_observations(failure_evidence: Any) -> list[dict[str, str]]:
+    """The scaffold evidence's fill-layer observations, one per (file, slot) (#970).
+
+    ``classify_shell_failures`` attributes an assertion failure inside a slot region
+    to the FILL layer with the slot id and the shell path — structured data, the
+    same source #1015 reads app-contract observations from. These are the sites an
+    own-artifact qa repair can reach: the shell files, addressed by slot.
+    """
+    if not isinstance(failure_evidence, dict):
+        return []
+    from squadops.cycles.scaffold_evidence import CLASS_FILL
+
+    summary = failure_evidence.get("scaffold_evidence")
+    observations = (summary.get("observations") or []) if isinstance(summary, dict) else []
+    seen: set[tuple[str, str]] = set()
+    out: list[dict[str, str]] = []
+    for obs in observations:
+        if not isinstance(obs, dict) or obs.get("failure_class") != CLASS_FILL:
+            continue
+        key = (str(obs.get("file") or ""), str(obs.get("slot_id") or ""))
+        if not key[0] or key in seen:
+            continue
+        seen.add(key)
+        out.append({"file": key[0], "slot_id": key[1], "detail": str(obs.get("detail") or "")})
+    return out
+
+
+def _qa_scaffold_repair_inputs(
+    role: str, failed_inputs: dict[str, Any], failed_result: Any, failure_evidence: Any
+) -> dict[str, Any]:
+    """What a qa repair of a scaffold-bound task needs to reach a fill (#970, 1.6.5 D).
+
+    Presence-keyed: only a qa-role step repairing a task that carried the scaffold
+    receives anything. The scaffold rides as the task was authored against it
+    (pristine shells, manifest, tables, element kinds) plus ``current_files`` — the
+    failed task's stored artifacts at shell paths, i.e. the shells WITH the fills the
+    task merged — so the repair can replace one slot and keep every other byte for
+    byte; ``repair_slots`` names the failing slots for the brief.
+    """
+    scaffold_input = failed_inputs.get("verification_scaffold")
+    if role != "qa" or not isinstance(scaffold_input, dict):
+        return {}
+    shell_paths = {str(f.get("name")) for f in (scaffold_input.get("files") or [])}
+    artifacts = (getattr(failed_result, "outputs", None) or {}).get("artifacts") or []
+    current_files = [
+        {"name": str(a["name"]), "content": str(a.get("content") or "")}
+        for a in artifacts
+        if isinstance(a, dict) and a.get("name") in shell_paths
+    ]
+    return {
+        "verification_scaffold": {**scaffold_input, "current_files": current_files},
+        "repair_slots": _fill_observations(failure_evidence),
+    }
+
+
 def _empty_emission_signature(result: Any) -> list[str]:
     """The #998 signature a repair step's handler put on its ``emission_failure`` marker,
     as a zero-or-one-element list so the caller can ``extend`` without branching."""
@@ -559,6 +614,29 @@ def _locus_and_repair_target(
 
     failure_locus = classify_failure_locus(failure_evidence)
     own_expected = [str(e) for e in (failed_inputs.get("expected_artifacts") or []) if e]
+    # #970 (1.6.5 D): under fill mode the shells are merge products, never in
+    # ``expected_artifacts``, so aiming the own-artifact repair at the plan's declared
+    # file left a failing FILL structurally unreachable — roll 6 of the 1.6.4 set
+    # re-produced ``__tests__/runs.test.ts`` twice while every shell rendered "no
+    # fill received". When the failed task carried the scaffold and the evidence
+    # names fill-layer observations, the target is their shells, by slot.
+    fill_sites = (
+        _fill_observations(failure_evidence) if failed_inputs.get("verification_scaffold") else []
+    )
+    if failure_locus == FailureLocus.OWN_ARTIFACT and fill_sites:
+        shells = list(dict.fromkeys(site["file"] for site in fill_sites))
+        logger.info(
+            "correction_repair_locus: own_artifact — %s re-fills slot(s) %s in %s (#970)",
+            failed_task_type,
+            ", ".join(site["slot_id"] or "?" for site in fill_sites),
+            ", ".join(shells),
+        )
+        return (
+            failure_locus,
+            shells,
+            failed_inputs.get("subtask_focus"),
+            failed_inputs.get("subtask_description"),
+        )
     if failure_locus == FailureLocus.OWN_ARTIFACT and own_expected:
         logger.info(
             "correction_repair_locus: own_artifact — %s re-produces %s",
@@ -1491,6 +1569,11 @@ class CorrectionRunner:
                 # stripping the anchors — hence the registry-declared
                 # re-derivation above (presence-keyed: no manifest, no keys).
                 repair_inputs.update(repair_surfaces)
+                # #970 (1.6.5 D), presence-keyed: the scaffold + the task's current
+                # merged shells + the slots whose fills failed, for a qa repair.
+                repair_inputs.update(
+                    _qa_scaffold_repair_inputs(role, failed_inputs, result, failure_evidence)
+                )
 
                 repair_envelope = TaskEnvelope(
                     task_id=repair_task_id,

--- a/src/squadops/capabilities/handlers/cycle/fill_mode_brief.py
+++ b/src/squadops/capabilities/handlers/cycle/fill_mode_brief.py
@@ -1,0 +1,107 @@
+"""The fill-mode brief — one composition seam for every qa-role dispatch (#969).
+
+``qa.test`` (initial authoring), its self-eval pass (#947) and ``qa.test_repair`` (#970)
+all author against the same frozen scaffold, so they read one description of the slot
+protocol, the store vocabulary, the error envelope and the in-process execution model.
+#969 counted three instances of a protocol taught to the primary path while a sibling
+path silently kept the old behaviour; the answer to its question — a fourth appendix, or
+one seam — is this module. Every instruction lives in the managed assets (#448); the
+functions here derive the data the assets render.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+FILL_MODE_TEMPLATE = "request.qa_test_fill_mode_appendix"
+SELF_EVAL_FILL_TEMPLATE = "request.qa_test_self_eval_fill_appendix"
+REPAIR_FILL_TEMPLATE = "request.qa_test_repair_fill_appendix"
+
+
+async def render_fill_mode_section(
+    renderer: Any, scaffold_input: dict[str, Any] | None, additive_files: Sequence[str] | None
+) -> str:
+    """The FILL MODE block for a scaffold-carrying envelope, or "".
+
+    SIP-0104 §4.5: the author receives the shells (read-only) and the coverage
+    inventory — data derived from the slot table by the fill module. Coverage
+    inventory only: no generated coaching (SIP §12 keeps richer briefs as follow-on).
+    """
+    scaffold_input = scaffold_input or {}
+    manifest_dict = scaffold_input.get("manifest")
+    files = scaffold_input.get("files") or []
+    if renderer is None or not manifest_dict or not files:
+        return ""
+    from squadops.capabilities.scaffold import error_envelope_lines
+    from squadops.capabilities.verification_scaffold import VerificationScaffoldManifest
+    from squadops.capabilities.verification_scaffold_fill import coverage_inventory_lines
+
+    record = VerificationScaffoldManifest.from_dict(manifest_dict)
+    slot_lines = "\n".join(f"- {line}" for line in coverage_inventory_lines(record))
+    shell_parts = [f"**{f['name']}:**\n```typescript\n{f['content']}\n```" for f in files]
+    # #911: half the slots are error behaviors and nothing showed the author the
+    # envelope, so it invented `body.error_code` on two consecutive window rolls.
+    # Keyed on the scaffold record's own stack — the fact is the stack's, not the run's.
+    envelope = "\n".join(f"- {line}" for line in error_envelope_lines(record.stack))
+    # #933: the plan's authored deliverable, reframed as additive by the asset that
+    # owns the emission contract.
+    additive = "\n".join(f"- `{f}`" for f in (additive_files or []))
+    rendered = await renderer.render(
+        FILL_MODE_TEMPLATE,
+        {
+            "slot_lines": slot_lines,
+            "shell_files": "\n\n".join(shell_parts),
+            "error_envelope": envelope,
+            "additive_files": additive,
+        },
+    )
+    return rendered.content
+
+
+def _disposition_lines(
+    dispositions: Sequence[dict[str, Any]], *, exclude: str | None = "filled"
+) -> list[str]:
+    return [
+        f"- `{d['slot_id']}` — {d['disposition']}" + (f": {d['detail']}" if d.get("detail") else "")
+        for d in dispositions
+        if d.get("disposition") != exclude
+    ]
+
+
+async def render_self_eval_fill_section(
+    renderer: Any, fill_merge_evidence: dict[str, Any] | None
+) -> str:
+    """The fill-mode addendum to the self-eval prompt (#947), or "".
+
+    Names the slots whose disposition is not ``filled`` — data from the merge record.
+    """
+    if renderer is None:
+        return ""
+    unfilled = _disposition_lines((fill_merge_evidence or {}).get("dispositions", []))
+    rendered = await renderer.render(
+        SELF_EVAL_FILL_TEMPLATE, {"unfilled_slot_lines": "\n".join(unfilled) or "(none)"}
+    )
+    return rendered.content
+
+
+async def render_repair_fill_section(
+    renderer: Any, repair_slots: Sequence[dict[str, Any]] | None
+) -> str:
+    """The fill-mode addendum to a qa repair prompt (#970), or "".
+
+    Names the slots whose fills failed (the runner threads them from the scaffold
+    evidence's fill-layer observations) with the runner's own failure detail.
+    """
+    if renderer is None or not repair_slots:
+        return ""
+    lines = [
+        f"- `{r['slot_id']}` in `{r.get('file', '')}`"
+        + (f" — {r['detail']}" if r.get("detail") else "")
+        for r in repair_slots
+        if r.get("slot_id")
+    ]
+    if not lines:
+        return ""
+    rendered = await renderer.render(REPAIR_FILL_TEMPLATE, {"failed_slot_lines": "\n".join(lines)})
+    return rendered.content

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -35,6 +35,10 @@ if TYPE_CHECKING:
     from squadops.capabilities.handlers.context import ExecutionContext
 
 from squadops.capabilities.handlers.cycle.base import _CycleTaskHandler
+from squadops.capabilities.handlers.cycle.fill_mode_brief import (
+    render_fill_mode_section,
+    render_self_eval_fill_section,
+)
 from squadops.capabilities.handlers.cycle.validation import (
     _STUB_THRESHOLD_BYTES,
     ValidationResult,
@@ -527,46 +531,14 @@ class QATestHandler(_CycleTaskHandler):
     async def _fill_mode_section(self, context: ExecutionContext, inputs: dict[str, Any]) -> str:
         """Render the FILL MODE block when the envelope carries the scaffold, or "".
 
-        SIP-0104 §4.5: the author receives the shells (read-only) and the coverage
-        inventory — data derived from the slot table by the fill module; every
-        instruction lives in the managed asset (#448). Coverage inventory only: no
-        generated coaching (SIP §12 keeps richer briefs as follow-on work).
+        One composition seam for every qa-role dispatch (#969): the brief is built in
+        ``fill_mode_brief`` and shared with the self-eval pass and ``qa.test_repair``.
         """
-        scaffold_input = inputs.get("verification_scaffold") or {}
-        manifest_dict = scaffold_input.get("manifest")
-        files = scaffold_input.get("files") or []
-        if not manifest_dict or not files:
-            return ""
-        renderer = getattr(context.ports, "request_renderer", None)
-        if renderer is None:
-            return ""
-        from squadops.capabilities.scaffold import error_envelope_lines
-        from squadops.capabilities.verification_scaffold import VerificationScaffoldManifest
-        from squadops.capabilities.verification_scaffold_fill import coverage_inventory_lines
-
-        record = VerificationScaffoldManifest.from_dict(manifest_dict)
-        slot_lines = "\n".join(f"- {line}" for line in coverage_inventory_lines(record))
-        shell_parts = [f"**{f['name']}:**\n```typescript\n{f['content']}\n```" for f in files]
-        # #911: half the slots are error behaviors and nothing showed the author the
-        # envelope, so it invented `body.error_code` on two consecutive window rolls.
-        # Keyed on the scaffold record's own stack — the fact is the stack's, not the
-        # run's, so it stays correct when the brief is rendered without a manifest.
-        envelope = "\n".join(f"- {line}" for line in error_envelope_lines(record.stack))
-        # #933: the plan's authored deliverable, reframed as additive by the asset that
-        # owns the emission contract. The focused prompt no longer states it as an
-        # expected output file, so this is the only place it appears — the intent is
-        # kept, its precedence is not.
-        additive = "\n".join(f"- `{f}`" for f in (inputs.get("expected_artifacts") or []))
-        rendered = await renderer.render(
-            "request.qa_test_fill_mode_appendix",
-            {
-                "slot_lines": slot_lines,
-                "shell_files": "\n\n".join(shell_parts),
-                "error_envelope": envelope,
-                "additive_files": additive,
-            },
+        return await render_fill_mode_section(
+            getattr(context.ports, "request_renderer", None),
+            inputs.get("verification_scaffold"),
+            inputs.get("expected_artifacts") or [],
         )
-        return rendered.content
 
     async def _self_eval_fill_section(
         self,
@@ -574,27 +546,12 @@ class QATestHandler(_CycleTaskHandler):
         scaffold_input: dict[str, Any],
         fill_merge_evidence: dict[str, Any] | None,
     ) -> str:
-        """Render the fill-mode addendum to the self-eval prompt, or "" (1.6.5 C, #947).
-
-        The shared self-eval prompt asks for "the missing files"; under fill mode the
-        missing things are slots, which only a fill block can address. The addendum
-        names the slots whose disposition is not ``filled`` — data from the merge
-        record; every instruction lives in the managed asset (#448).
-        """
-        renderer = getattr(context.ports, "request_renderer", None)
-        if renderer is None or not scaffold_input:
+        """The fill-mode addendum to the self-eval prompt, or "" (1.6.5 C, #947)."""
+        if not scaffold_input:
             return ""
-        unfilled = [
-            f"- `{d['slot_id']}` — {d['disposition']}"
-            + (f": {d['detail']}" if d.get("detail") else "")
-            for d in (fill_merge_evidence or {}).get("dispositions", [])
-            if d.get("disposition") != "filled"
-        ]
-        rendered = await renderer.render(
-            "request.qa_test_self_eval_fill_appendix",
-            {"unfilled_slot_lines": "\n".join(unfilled) or "(none)"},
+        return await render_self_eval_fill_section(
+            getattr(context.ports, "request_renderer", None), fill_merge_evidence
         )
-        return rendered.content
 
     @staticmethod
     def _suite_files(artifacts: list[dict]) -> list[dict]:

--- a/src/squadops/capabilities/handlers/impl/repair_handlers.py
+++ b/src/squadops/capabilities/handlers/impl/repair_handlers.py
@@ -14,10 +14,13 @@ correction-loop flows have distinct, non-overlapping capability ids.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 from squadops.capabilities.handlers.cycle_tasks import _classify_file, _CycleTaskHandler
 from squadops.capabilities.handlers.fenced_parser import extract_fenced_files
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from squadops.capabilities.handlers.base import HandlerResult
@@ -229,6 +232,9 @@ class _RepairPromptMixin:
             # are the samples. Rendered in handle(); "" when the executor threaded no
             # counter (author-mode and legacy paths render byte-identically).
             "loop_state": str(inputs.get("loop_state_section") or ""),
+            # #970 / #969 (1.6.5 D): the SAME fill-mode brief qa.test authored under,
+            # plus the slots whose fills failed. "" for non-qa repairs or no scaffold.
+            "qa_fill_mode_section": str(inputs.get("qa_fill_mode_section") or ""),
         }
 
     async def handle(
@@ -262,7 +268,37 @@ class _RepairPromptMixin:
         loop_state = await self._render_loop_state_section(context, inputs)
         if loop_state:
             inputs = {**inputs, "loop_state_section": loop_state}
+        qa_fill_mode = await self._render_qa_fill_mode_section(context, inputs)
+        if qa_fill_mode:
+            inputs = {**inputs, "qa_fill_mode_section": qa_fill_mode}
         return await super().handle(context, inputs)
+
+    async def _render_qa_fill_mode_section(
+        self, context: ExecutionContext, inputs: dict[str, Any]
+    ) -> str:
+        """The qa fill-mode brief for a scaffold-bound repair, or "" (#969, #970).
+
+        Third instance of the missing-brief pattern, closed at the seam rather than
+        with a fourth appendix: the repair renders the SAME fill-mode section
+        ``qa.test`` authored under (slot protocol, store vocabulary, error envelope,
+        in-process execution model) through ``fill_mode_brief``, followed by the
+        repair addendum naming the slots whose fills failed.
+        """
+        if self._role != "qa" or not inputs.get("verification_scaffold"):
+            return ""
+        renderer = getattr(context.ports, "request_renderer", None)
+        if renderer is None:
+            return ""
+        from squadops.capabilities.handlers.cycle.fill_mode_brief import (
+            render_fill_mode_section,
+            render_repair_fill_section,
+        )
+
+        brief = await render_fill_mode_section(
+            renderer, inputs.get("verification_scaffold"), inputs.get("expected_artifacts") or []
+        )
+        addendum = await render_repair_fill_section(renderer, inputs.get("repair_slots"))
+        return "\n\n".join(part for part in (brief, addendum) if part)
 
     async def _render_loop_state_section(
         self, context: ExecutionContext, inputs: dict[str, Any]
@@ -654,4 +690,127 @@ class QATestRepairHandler(_RepairPromptMixin, _CycleTaskHandler):
     _artifact_name = "repair_output.md"
 
     def _build_artifacts_from_content(self, content: str) -> list[dict[str, Any]]:
-        return _artifacts_from_fenced_blocks(content, self._artifact_name)
+        """Fill blocks become ``type: "fill"`` artifacts keyed by slot id (#970).
+
+        Left to the file extractor they parse as files named ``slot-…`` — the shape
+        the shell guard discards and roll 6 of the 1.6.4 set banked eight of. The
+        merge into the shells happens in :meth:`handle`, where the scaffold is known.
+        """
+        from squadops.capabilities.verification_scaffold_fill import (
+            parse_fill_emission,
+            strip_fill_blocks,
+        )
+
+        fills = parse_fill_emission(content)
+        fill_artifacts = [
+            {
+                "name": f.slot_id,
+                "content": f"not_applicable: {f.not_applicable_reason}"
+                if f.is_not_applicable
+                else f.body,
+                "media_type": "text/plain",
+                "type": "fill",
+            }
+            for f in fills.fills
+        ]
+        rest = strip_fill_blocks(content) if fills.fills else content
+        if fill_artifacts and not extract_fenced_files(rest):
+            return fill_artifacts
+        return fill_artifacts + _artifacts_from_fenced_blocks(rest, self._artifact_name)
+
+    async def handle(
+        self,
+        context: ExecutionContext,
+        inputs: dict[str, Any],
+    ) -> HandlerResult:
+        result = await super().handle(context, inputs)
+        scaffold_input = inputs.get("verification_scaffold")
+        if scaffold_input and isinstance(result.outputs, dict):
+            artifacts, evidence = _merge_repair_fills(
+                scaffold_input, list(result.outputs.get("artifacts") or [])
+            )
+            result.outputs["artifacts"] = artifacts
+            result.outputs["fill_merge"] = evidence
+            logger.info(
+                "qa_test_repair_handler fill merge: applied=%s dropped_shell_rewrites=%s counts=%s",
+                evidence.get("applied"),
+                evidence.get("dropped_shell_rewrites"),
+                evidence.get("counts"),
+            )
+        return result
+
+
+def _merge_repair_fills(
+    scaffold_input: dict[str, Any], artifacts: list[dict[str, Any]]
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Merge a repair's fill artifacts into the task's current shells (#970, 1.6.5 D).
+
+    The repair emits fill blocks for the failing slots; the shells it must produce
+    are the task's CURRENT merged shells (``current_files``, threaded by the runner
+    from the failed task's stored artifacts) with those slots replaced. Every other
+    slot's fill is recovered from the current shell and kept byte for byte; the
+    result passes the same merge gate the primary did (#1087 tables, #1094 element
+    kinds) and is emitted at the shell path, so the patch overlay supersedes the
+    failed shell by name and the retest runs it. A whole-shell rewrite emitted as a
+    path fence is dropped and recorded, as on every other qa path.
+    """
+    from squadops.capabilities.verification_scaffold import VerificationScaffoldManifest
+    from squadops.capabilities.verification_scaffold_fill import (
+        apply_followup_fills,
+        merge_fills,
+        parse_fill_emission,
+        recover_fills,
+    )
+
+    record = VerificationScaffoldManifest.from_dict(scaffold_input["manifest"])
+    shell_paths = {f.path for f in record.files}
+    fill_artifacts = [a for a in artifacts if a.get("type") == "fill"]
+    dropped = sorted(a["name"] for a in artifacts if a.get("name") in shell_paths)
+    kept = [a for a in artifacts if a.get("type") != "fill" and a.get("name") not in shell_paths]
+    evidence: dict[str, Any] = {"dropped_shell_rewrites": dropped, "applied": [], "counts": {}}
+    current = list(scaffold_input.get("current_files") or [])
+    if not fill_artifacts:
+        evidence["detail"] = "the repair emitted no fill block"
+        return kept, evidence
+    if not current:
+        evidence["detail"] = "no current shells were threaded; fills could not be merged"
+        return kept, evidence
+    text = "".join(f"```fill:{a['name']}\n{a['content']}\n```\n" for a in fill_artifacts)
+    repair_fills = parse_fill_emission(text)
+    base, dispositions = recover_fills(current, record)
+    folded = apply_followup_fills(base, repair_fills, dispositions, replace_filled=True)
+    merged = merge_fills(
+        list(scaffold_input["files"]),
+        record,
+        folded.emission,
+        store_tables=scaffold_input.get("store_tables"),
+        slot_element_kinds=scaffold_input.get("slot_element_kinds"),
+    )
+    touched_paths = {
+        f.path for f in record.files if any(s.slot_id in folded.applied for s in f.slots)
+    }
+    merged_artifacts = [
+        {
+            "name": f.path,
+            "content": f.content,
+            "media_type": _classify_file(f.path)[1],
+            "type": "test",
+        }
+        for f in merged.files
+        if f.path in touched_paths
+    ]
+    evidence.update(
+        {
+            "applied": list(folded.applied),
+            "counts": merged.disposition_counts(),
+            "dispositions": [
+                {"slot_id": d.slot_id, "disposition": d.disposition, "detail": d.detail}
+                for d in merged.dispositions
+                if d.slot_id in folded.applied
+            ],
+            "misaddressed": [
+                {"slot_id": d.slot_id, "detail": d.detail} for d in merged.misaddressed
+            ],
+        }
+    )
+    return kept + merged_artifacts, evidence

--- a/src/squadops/capabilities/verification_scaffold_fill.py
+++ b/src/squadops/capabilities/verification_scaffold_fill.py
@@ -540,13 +540,17 @@ def apply_followup_fills(
     base: FillEmission,
     followup: FillEmission,
     dispositions: Sequence[Mapping[str, Any]],
+    *,
+    replace_filled: bool = False,
 ) -> FollowupFillMerge:
     """Fold a self-eval emission's fills into the primary emission.
 
     A followup fill lands on a slot whose current disposition is anything but
     ``filled`` (missing, rejected, not_applicable, or a duplicate); a slot already
     filled keeps its primary fill and the re-emission is recorded, not applied. The
-    followup's own duplicates stay duplicates. Roll 6 of the 1.6.4 set is the case:
+    followup's own duplicates stay duplicates. ``replace_filled`` is the repair's
+    setting (#970): a repair is told which slots failed and may replace a filled slot;
+    a self-eval asked for "only what is missing" may not. Roll 6 of the 1.6.4 set is the case:
     the primary hit the completion cap with zero fills, the self-eval re-emitted all
     eight, and the handler threw them away because it only knew how to drop shell
     paths.
@@ -561,7 +565,7 @@ def apply_followup_fills(
     for f in followup.fills:
         if f.slot_id in followup_dups:
             continue
-        if f.slot_id in filled:
+        if f.slot_id in filled and not replace_filled:
             skipped.append(f.slot_id)
             continue
         fills[f.slot_id] = f
@@ -581,6 +585,67 @@ def apply_followup_fills(
         applied=tuple(dict.fromkeys(applied)),
         skipped_filled=tuple(dict.fromkeys(skipped)),
     )
+
+
+#: The first line ``_merged_body`` writes for each non-filled disposition. Recovery
+#: reads them back; they are the only shapes a merged slot body can take besides a fill.
+_FAILING_STATE_PREFIX = "    // fill layer: "
+_NOT_APPLICABLE_PREFIX = "    // not_applicable (qa): "
+
+
+def recover_fills(
+    merged_files: Sequence[Mapping[str, str]], record: VerificationScaffoldManifest
+) -> tuple[FillEmission, list[dict[str, str]]]:
+    """Read the fills back out of merged shells (#970, 1.6.5 D).
+
+    A qa repair replaces one slot's fill and must keep every other slot exactly as
+    the task left it — but the task's fill emission is not stored, only the merged
+    shells are. Each slot body is one of three shapes ``_merged_body`` writes: a fill
+    (returned as a :class:`Fill`), an explicit not-applicable line (returned as an NA
+    fill), or the deterministic failing state (returned as no fill, disposition
+    ``missing``). Round-trip property: ``merge_fills(pristine, record,
+    recover_fills(merged)[0])`` reproduces ``merged`` byte for byte.
+
+    Returns ``(emission, dispositions)`` in the shape the merge record banks, so the
+    result feeds :func:`apply_followup_fills` directly.
+    """
+    by_path = {str(f["name"]): str(f["content"]) for f in merged_files}
+    fills: list[Fill] = []
+    dispositions: list[dict[str, str]] = []
+    for file_record in record.files:
+        content = by_path.get(file_record.path)
+        if content is None:
+            for slot in file_record.slots:
+                dispositions.append(
+                    {"slot_id": slot.slot_id, "disposition": DISPOSITION_MISSING, "detail": ""}
+                )
+            continue
+        lines = content.split("\n")
+        regions = {r.slot_id: r for r in parse_slot_regions(content)}
+        for slot in file_record.slots:
+            region = regions.get(slot.slot_id)
+            body = lines[region.begin_line : region.end_line - 1] if region else []
+            first = body[0] if body else ""
+            if not body or first.startswith(_FAILING_STATE_PREFIX):
+                dispositions.append(
+                    {"slot_id": slot.slot_id, "disposition": DISPOSITION_MISSING, "detail": ""}
+                )
+            elif first.startswith(_NOT_APPLICABLE_PREFIX):
+                reason = first[len(_NOT_APPLICABLE_PREFIX) :]
+                fills.append(Fill(slot_id=slot.slot_id, not_applicable_reason=reason))
+                dispositions.append(
+                    {
+                        "slot_id": slot.slot_id,
+                        "disposition": DISPOSITION_NOT_APPLICABLE,
+                        "detail": reason,
+                    }
+                )
+            else:
+                fills.append(Fill(slot_id=slot.slot_id, body="\n".join(body)))
+                dispositions.append(
+                    {"slot_id": slot.slot_id, "disposition": DISPOSITION_FILLED, "detail": ""}
+                )
+    return FillEmission(fills=tuple(fills)), dispositions
 
 
 def strip_fill_blocks(text: str) -> str:

--- a/src/squadops/prompts/request_templates/request.cycle_repair_task.md
+++ b/src/squadops/prompts/request_templates/request.cycle_repair_task.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.cycle_repair_task
-version: "4"
+version: "5"
 required_variables:
   - prd
   - role
@@ -18,11 +18,13 @@ optional_variables:
   - dom_anchor_section
   - frozen_surface_section
   - loop_state
+  - qa_fill_mode_section
 ---
 ## Repair Task
 
 You are repairing a failed `{{failed_task_type}}` task. Your job is to re-produce the named output artifact(s) below so they satisfy the acceptance criteria. Do not rewrite the PRD, do not produce a status tracker, do not emit a generic narrative document.
 {{fill_only_section}}
+{{qa_fill_mode_section}}
 {{contract_expectations}}
 {{dom_anchor_section}}
 {{frozen_surface_section}}

--- a/src/squadops/prompts/request_templates/request.qa_test_repair_fill_appendix.md
+++ b/src/squadops/prompts/request_templates/request.qa_test_repair_fill_appendix.md
@@ -1,0 +1,30 @@
+---
+template_id: request.qa_test_repair_fill_appendix
+version: "1"
+required_variables:
+  - failed_slot_lines
+---
+
+## FILL MODE REPAIR — the slots whose fills failed
+
+The FILL MODE section above is the contract you author under here too: assertions
+only, `all(TABLES.<Entity>)`, the element kind read off the frozen floor, in-process
+execution with no server. The scaffold files are read-only: a path-addressed file at
+a scaffold path is discarded, and a **fill block is the only way to change a slot**.
+
+**These slots failed, with the runner's own reason:**
+{{failed_slot_lines}}
+
+Emit one replacement fill block per slot listed — **first, before anything else** — and
+nothing for slots not listed unless the failure reason above implicates them. Every
+other slot keeps the fill it already has, byte for byte.
+
+```fill:slot-<id>
+    expect(body.id).toBeTruthy()
+    expect(all(TABLES.Run)).toHaveLength(1)
+```
+
+Fix the fill, not the application: if the reason above says the response or the store
+did not match what the fill asserted, and the fill asserted something the contract does
+not declare, correct the fill; a fill the shell's frozen floor already contradicts is
+rejected at the gate with the declared kind named.

--- a/tests/unit/capabilities/test_qa_repair_fill_path.py
+++ b/tests/unit/capabilities/test_qa_repair_fill_path.py
@@ -1,0 +1,219 @@
+"""A qa repair can reach a fill — 1.6.5 D (#970, with #969's brief).
+
+Under fill mode the shells are merge products. Before this the own-artifact repair emitted
+whole files (0 fills, 1 path fence — #969's observation), the shell guard discarded them,
+and the retest ran the unrepaired suite. Now the repair authors under the SAME fill-mode
+brief as ``qa.test``, emits fill blocks, and the handler merges them into the task's
+current shells through the same gate; the merged shell is emitted at the shell path so the
+patch overlay supersedes the failed one by name.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from squadops.capabilities.handlers.impl.repair_handlers import (
+    QATestRepairHandler,
+    _merge_repair_fills,
+)
+from squadops.capabilities.verification_scaffold_emission import emit_verification_scaffold
+from squadops.capabilities.verification_scaffold_fill import merge_fills, parse_fill_emission
+from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_TEMPLATES = (
+    Path(__file__).resolve().parents[3] / "src" / "squadops" / "prompts" / "request_templates"
+)
+_JOIN = "__tests__/scaffold/vc-probe-api-runs-join.scaffold.test.ts"
+_CREATE = "__tests__/scaffold/vc-probe-api-runs.scaffold.test.ts"
+_SLOTS = [
+    "vc-probe-api-runs",
+    "vc-probe-api-runs-rejects-blank",
+    "vs-get-api-runs",
+    "vs-get-api-runs-run-id",
+    "vs-get-api-runs-run-id-not-found",
+    "vc-probe-api-runs-join",
+    "vc-probe-api-runs-join-duplicate",
+    "vc-probe-api-runs-leave",
+]
+
+
+@pytest.fixture(scope="module")
+def scaffold_input():
+    """The scaffold as the repair receives it: pristine files + the task's CURRENT
+    shells, which carry eight fills (the join one is the wrong one)."""
+    emission = emit_verification_scaffold(manifest_for_stack("nextjs_ts"))
+    files = [dict(f) for f in emission.files]
+    primary = parse_fill_emission(
+        "".join(f"```fill:slot-{s}\n    expect(body).toBeTruthy() // {s}\n```\n" for s in _SLOTS)
+    )
+    merged = merge_fills(files, emission.manifest, primary)
+    return {
+        "manifest": emission.manifest.to_dict(),
+        "files": files,
+        "store_tables": ["Run"],
+        "current_files": [{"name": f.path, "content": f.content} for f in merged.files],
+    }
+
+
+def _art(name, content, type_="test"):
+    return {"name": name, "content": content, "media_type": "x", "type": type_}
+
+
+class TestMergeRepairFills:
+    def test_one_slot_is_replaced_and_every_other_byte_is_kept(self, scaffold_input):
+        artifacts = QATestRepairHandler()._build_artifacts_from_content(
+            "```fill:slot-vc-probe-api-runs-join\n    expect(body.participants).toHaveLength(1)\n```\n"
+        )
+        out, evidence = _merge_repair_fills(scaffold_input, artifacts)
+
+        assert [a["name"] for a in out] == [_JOIN]  # only the touched shell is emitted
+        assert out[0]["type"] == "test"
+        assert "expect(body.participants).toHaveLength(1)" in out[0]["content"]
+        assert "// vc-probe-api-runs-join" not in out[0]["content"]
+        assert evidence["applied"] == ["slot-vc-probe-api-runs-join"]
+        assert evidence["counts"] == {"filled": 8}
+        # the untouched shells would be reproduced byte for byte (round-trip property)
+        current = {f["name"]: f["content"] for f in scaffold_input["current_files"]}
+        assert (
+            "// vc-probe-api-runs-leave"
+            in current["__tests__/scaffold/vc-probe-api-runs-leave.scaffold.test.ts"]
+        )
+
+    def test_a_whole_shell_rewrite_is_dropped_and_recorded(self, scaffold_input):
+        artifacts = [
+            _art(_CREATE, "// REWRITTEN"),
+            *QATestRepairHandler()._build_artifacts_from_content(
+                "```fill:slot-vc-probe-api-runs\n    expect(1).toBe(1)\n```\n"
+            ),
+        ]
+        out, evidence = _merge_repair_fills(scaffold_input, artifacts)
+        assert evidence["dropped_shell_rewrites"] == [_CREATE]
+        create = next(a for a in out if a["name"] == _CREATE)
+        assert "REWRITTEN" not in create["content"]
+        assert "expect(1).toBe(1)" in create["content"]
+
+    def test_a_repair_fill_passes_the_same_gate_as_the_primary(self, scaffold_input):
+        """#1087 on the repair path: a phantom-table fill is rejected with the real
+        tables named, exactly as qa.test would reject it."""
+        artifacts = QATestRepairHandler()._build_artifacts_from_content(
+            "```fill:slot-vc-probe-api-runs\n    expect(all(TABLES.Participant)).toHaveLength(1)\n```\n"
+        )
+        out, evidence = _merge_repair_fills(scaffold_input, artifacts)
+        assert evidence["counts"]["rejected"] == 1
+        assert evidence["dispositions"][0]["disposition"] == "rejected"
+        assert "`TABLES.Run`" in out[0]["content"]
+
+    def test_no_fill_emitted_keeps_the_additive_files_and_says_so(self, scaffold_input):
+        artifacts = [_art("__tests__/extra.test.ts", "// extra")]
+        out, evidence = _merge_repair_fills(scaffold_input, artifacts)
+        assert out == artifacts
+        assert evidence["detail"] == "the repair emitted no fill block"
+
+    def test_without_current_shells_nothing_is_merged_and_the_fills_do_not_leak(
+        self, scaffold_input
+    ):
+        artifacts = QATestRepairHandler()._build_artifacts_from_content(
+            "```fill:slot-vc-probe-api-runs\n    expect(1).toBe(1)\n```\n"
+        )
+        out, evidence = _merge_repair_fills(
+            {k: v for k, v in scaffold_input.items() if k != "current_files"}, artifacts
+        )
+        assert out == []
+        assert "no current shells" in evidence["detail"]
+
+
+class TestArtifactTyping:
+    def test_fill_blocks_become_fill_artifacts_and_files_stay_files(self):
+        arts = QATestRepairHandler()._build_artifacts_from_content(
+            "```fill:slot-a\n    x()\n```\n```fill:slot-b\nnot_applicable: covered\n```\n"
+            "```typescript:__tests__/extra.test.ts\n// extra\n```\n"
+        )
+        assert [(a["name"], a["type"]) for a in arts[:2]] == [
+            ("slot-a", "fill"),
+            ("slot-b", "fill"),
+        ]
+        assert arts[2]["name"] == "__tests__/extra.test.ts" and arts[2]["type"] != "fill"
+        assert arts[1]["content"] == "not_applicable: covered"
+
+    def test_no_fences_at_all_still_falls_back_to_the_document(self):
+        arts = QATestRepairHandler()._build_artifacts_from_content("just prose")
+        assert [a["name"] for a in arts] == ["repair_output.md"]
+
+
+async def test_handle_authors_under_the_qa_brief_and_merges_into_the_current_shell(
+    scaffold_input,
+):
+    handler = QATestRepairHandler()
+    renderer = AsyncMock()
+    renderer.render.return_value = MagicMock(
+        content="PROMPT", template_version="5", render_hash="h"
+    )
+    context = MagicMock()
+    context.ports.request_renderer = renderer
+    context.ports.llm.default_model = "m"
+    context.ports.llm.chat_stream_with_usage = AsyncMock(
+        return_value=MagicMock(
+            content="```fill:slot-vc-probe-api-runs-join\n    expect(body.participants).toHaveLength(1)\n```\n"
+        )
+    )
+    assembled = MagicMock()
+    assembled.content = "system"
+    context.ports.prompt_service.get_system_prompt = MagicMock(return_value=assembled)
+    context.correlation_context = None
+
+    result = await handler.handle(
+        context,
+        {
+            "prd": "group_run",
+            "failed_task_type": "qa.test",
+            "expected_artifacts": [_JOIN],
+            "verification_scaffold": scaffold_input,
+            "repair_slots": [
+                {
+                    "file": _JOIN,
+                    "slot_id": "slot-vc-probe-api-runs-join",
+                    "detail": "expected [] to have a length of 1",
+                }
+            ],
+        },
+    )
+
+    rendered = [c.args[0] for c in renderer.render.await_args_list]
+    assert rendered[:2] == [
+        "request.qa_test_fill_mode_appendix",
+        "request.qa_test_repair_fill_appendix",
+    ]
+    assert rendered[-1] == "request.cycle_repair_task"
+    variables = renderer.render.await_args_list[1].args[1]
+    assert "slot-vc-probe-api-runs-join" in variables["failed_slot_lines"]
+    assert "expected [] to have a length of 1" in variables["failed_slot_lines"]
+    main_vars = renderer.render.await_args_list[-1].args[1]
+    assert main_vars["qa_fill_mode_section"] == "PROMPT\n\nPROMPT"
+
+    names = [a["name"] for a in result.outputs["artifacts"]]
+    assert names == [_JOIN]
+    assert "expect(body.participants).toHaveLength(1)" in result.outputs["artifacts"][0]["content"]
+    assert result.outputs["fill_merge"]["applied"] == ["slot-vc-probe-api-runs-join"]
+
+
+async def test_the_repair_addendum_renders_from_the_real_asset():
+    from adapters.prompts.filesystem_asset_adapter import FilesystemPromptAssetAdapter
+    from squadops.capabilities.handlers.cycle.fill_mode_brief import render_repair_fill_section
+    from squadops.prompts.renderer import RequestTemplateRenderer
+
+    renderer = RequestTemplateRenderer(
+        FilesystemPromptAssetAdapter(
+            fragments_path=_TEMPLATES.parent / "fragments", templates_path=_TEMPLATES
+        )
+    )
+    out = await render_repair_fill_section(
+        renderer, [{"file": _JOIN, "slot_id": "slot-vc-probe-api-runs-join", "detail": "why"}]
+    )
+    assert "`slot-vc-probe-api-runs-join` in `" + _JOIN + "` — why" in out
+    assert "fill block is the only way to change a slot" in out
+    assert await render_repair_fill_section(renderer, []) == ""

--- a/tests/unit/capabilities/test_verification_scaffold_fill.py
+++ b/tests/unit/capabilities/test_verification_scaffold_fill.py
@@ -474,3 +474,64 @@ class TestApplyFollowupFills:
         assert "slot-a" in out.applied and "slot-a" not in out.emission.duplicates
         # slot-b is a duplicate in the followup; it stays rejected as such
         assert "slot-b" in out.emission.duplicates and "slot-b" not in out.applied
+
+
+class TestRecoverFills:
+    """1.6.5 D (#970): a repair replaces one slot and must keep every other byte for byte,
+    but the task's fill emission is not stored — only the merged shells are.
+
+    Bug caught: recovery misreads a merged body (a failing state taken for a fill, an NA
+    line lost, a body re-indented), so the repaired shell silently regresses a slot the
+    repair never touched.
+    """
+
+    @pytest.fixture(scope="class")
+    def scaffold(self):
+        from squadops.capabilities.verification_scaffold_emission import (
+            emit_verification_scaffold,
+        )
+        from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+        return emit_verification_scaffold(manifest_for_stack("nextjs_ts"))
+
+    def test_round_trip_reproduces_the_merged_shells_byte_for_byte(self, scaffold):
+        from squadops.capabilities.verification_scaffold_fill import merge_fills, recover_fills
+
+        files = [dict(f) for f in scaffold.files]
+        record = scaffold.manifest
+        emission = parse_fill_emission(
+            "```fill:slot-vc-probe-api-runs\n    expect(body.id).toBeTruthy()\n"
+            "    expect(all(TABLES.Run)).toHaveLength(1)\n```\n"
+            "```fill:slot-vc-probe-api-runs-leave\nnot_applicable: status says it all\n```\n"
+        )
+        first = merge_fills(files, record, emission)
+        merged = [{"name": f.path, "content": f.content} for f in first.files]
+
+        recovered, dispositions = recover_fills(merged, record)
+        by_slot = {d["slot_id"]: d["disposition"] for d in dispositions}
+        assert by_slot["slot-vc-probe-api-runs"] == "filled"
+        assert by_slot["slot-vc-probe-api-runs-leave"] == "not_applicable"
+        assert sum(1 for d in dispositions if d["disposition"] == "missing") == 6
+
+        second = merge_fills(files, record, recovered)
+        assert [f.content for f in second.files] == [f.content for f in first.files]
+
+    def test_a_missing_shell_reports_its_slots_missing(self, scaffold):
+        from squadops.capabilities.verification_scaffold_fill import recover_fills
+
+        recovered, dispositions = recover_fills([], scaffold.manifest)
+        assert recovered.fills == ()
+        assert {d["disposition"] for d in dispositions} == {"missing"}
+
+    def test_a_repair_may_replace_a_filled_slot_a_self_eval_may_not(self):
+        from squadops.capabilities.verification_scaffold_fill import apply_followup_fills
+
+        base = parse_fill_emission("```fill:slot-a\n    old()\n```\n")
+        followup = parse_fill_emission("```fill:slot-a\n    new()\n```\n")
+        disp = [{"slot_id": "slot-a", "disposition": "filled", "detail": ""}]
+        as_self_eval = apply_followup_fills(base, followup, disp)
+        as_repair = apply_followup_fills(base, followup, disp, replace_filled=True)
+        assert [f.body.strip() for f in as_self_eval.emission.fills] == ["old()"]
+        assert as_self_eval.skipped_filled == ("slot-a",)
+        assert [f.body.strip() for f in as_repair.emission.fills] == ["new()"]
+        assert as_repair.applied == ("slot-a",)

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -4739,3 +4739,120 @@ class TestAnalyzerImplicatedFilesAreVerifiedBeforeUse:
         with_claim, _, _ = _resolve_repair_target(self.SUITE_FAIL, dict(self.INPUTS), analysis)
         without, _, _ = _resolve_repair_target(self.SUITE_FAIL, dict(self.INPUTS))
         assert with_claim == without
+
+
+class TestQaRepairReachesFills:
+    """1.6.5 D (#970): an own-artifact qa repair of a scaffold-bound task targets the
+    shell of the failing slot and receives the task's current shells.
+
+    Bug caught: the own-artifact branch aims at ``expected_artifacts`` (the plan's
+    declared additive file), so a failing FILL is structurally unreachable — roll 6 of
+    the 1.6.4 set re-produced ``__tests__/runs.test.ts`` twice while every shell rendered
+    "no fill received".
+    """
+
+    _SHELL = "__tests__/scaffold/vc-probe-api-runs-join.scaffold.test.ts"
+
+    def _evidence(self, *, klass="fill"):
+        return {
+            "scaffold_evidence": {
+                "failure_classes": {klass: 1},
+                "observations": [
+                    {
+                        "file": self._SHELL,
+                        "slot_id": "slot-vc-probe-api-runs-join",
+                        "failure_class": klass,
+                        "detail": "slot disposition filled: expected [] to have a length of 1",
+                        "criterion_id": "vc-probe-api-runs-join" if klass != "fill" else "",
+                    }
+                ],
+            }
+        }
+
+    def _inputs(self, *, with_scaffold=True):
+        inputs = {
+            "expected_artifacts": ["__tests__/runs.test.ts"],
+            "subtask_focus": "qa",
+            "subtask_description": "author the suite",
+        }
+        if with_scaffold:
+            inputs["verification_scaffold"] = {
+                "manifest": {},
+                "files": [{"name": self._SHELL, "content": "// pristine"}],
+            }
+        return inputs
+
+    def test_fill_observations_are_read_per_file_and_slot(self):
+        from adapters.cycles.correction_runner import _fill_observations
+
+        assert _fill_observations(self._evidence()) == [
+            {
+                "file": self._SHELL,
+                "slot_id": "slot-vc-probe-api-runs-join",
+                "detail": "slot disposition filled: expected [] to have a length of 1",
+            }
+        ]
+        assert _fill_observations(self._evidence(klass="app_contract")) == []
+        assert _fill_observations({}) == []
+
+    def test_the_own_artifact_target_is_the_failing_slots_shell(self):
+        from adapters.cycles.correction_runner import _locus_and_repair_target
+        from squadops.cycles.failure_evidence import FailureLocus
+
+        locus, expected, focus, description = _locus_and_repair_target(
+            "qa.test", self._evidence(), self._inputs()
+        )
+        assert locus == FailureLocus.OWN_ARTIFACT
+        assert expected == [self._SHELL]
+        assert (focus, description) == ("qa", "author the suite")
+
+    def test_without_the_scaffold_the_target_is_the_declared_file_as_before(self):
+        from adapters.cycles.correction_runner import _locus_and_repair_target
+
+        _, expected, _, _ = _locus_and_repair_target(
+            "qa.test", self._evidence(), self._inputs(with_scaffold=False)
+        )
+        assert expected == ["__tests__/runs.test.ts"]
+
+    def test_an_app_contract_failure_never_takes_the_qa_branch(self):
+        from adapters.cycles.correction_runner import _locus_and_repair_target
+        from squadops.cycles.failure_evidence import FailureLocus
+
+        locus, expected, _, _ = _locus_and_repair_target(
+            "qa.test", self._evidence(klass="app_contract"), self._inputs()
+        )
+        assert locus == FailureLocus.SUBJECT
+        assert self._SHELL not in expected
+
+    def test_the_qa_repair_receives_the_current_shells_and_the_failing_slots(self):
+        from adapters.cycles.correction_runner import _qa_scaffold_repair_inputs
+
+        failed_result = MagicMock()
+        failed_result.outputs = {
+            "artifacts": [
+                {"name": self._SHELL, "content": "// merged, with fills", "type": "test"},
+                {"name": "__tests__/runs.test.ts", "content": "// additive", "type": "test"},
+                {"name": "test_report.md", "content": "r", "type": "test_report"},
+            ]
+        }
+        out = _qa_scaffold_repair_inputs("qa", self._inputs(), failed_result, self._evidence())
+        assert out["verification_scaffold"]["files"] == [
+            {"name": self._SHELL, "content": "// pristine"}
+        ]
+        assert out["verification_scaffold"]["current_files"] == [
+            {"name": self._SHELL, "content": "// merged, with fills"}
+        ]
+        assert [s["slot_id"] for s in out["repair_slots"]] == ["slot-vc-probe-api-runs-join"]
+
+    @pytest.mark.parametrize(
+        "role, with_scaffold",
+        [("dev", True), ("qa", False)],
+        ids=["foreign-role", "no-scaffold"],
+    )
+    def test_presence_keyed_nothing_otherwise(self, role, with_scaffold):
+        from adapters.cycles.correction_runner import _qa_scaffold_repair_inputs
+
+        out = _qa_scaffold_repair_inputs(
+            role, self._inputs(with_scaffold=with_scaffold), MagicMock(outputs={}), self._evidence()
+        )
+        assert out == {}


### PR DESCRIPTION
## What

The 1.6.5 plan's item **D** (`docs/plans/1-6-5-plan.md` rev 3 §2.1): an own-artifact qa repair can reach a fill. Three commits — the seam, the runner, the handler.

**The defect** (#970, observed live on roll 6 of the previous set): under fill mode the shells are merge products and never in `expected_artifacts`, so the own-artifact branch aimed the repair at the plan's declared file (`__tests__/runs.test.ts`) while every shell rendered "no fill received". #969 is what the repair then wrote: 0 fills, one whole file behind a path fence, blind to the fill protocol and the in-process execution model.

**The fix, in the shape the plan named — the 1.6.4 resolver's own pattern, not a second resolver:**
- **Targeting** (`correction_runner.py`): the target is the shell of each fill-layer observation in the scaffold evidence — the same structured data #1015 reads app-contract observations from. `_qa_scaffold_repair_inputs` threads the scaffold plus the failed task's **current** merged shells and the failing slots onto the repair envelope, presence-keyed (qa-role step, scaffold-bound task); everything else is byte-identical to before.
- **Brief** (`fill_mode_brief.py`, #969): one composition seam. `qa.test`, its self-eval and `qa.test_repair` now render the same FILL MODE section from the same asset; the repair adds `request.qa_test_repair_fill_appendix` (v1) naming the failed slots with the runner's reason. `cycle_repair_task` v5 carries the section.
- **Emission** (`QATestRepairHandler`): fill blocks are typed `fill` (not files named `slot-…`); `handle()` recovers every other slot's fill from the current shells (`recover_fills`, pinned by the round-trip property — recover then re-merge reproduces the shell byte for byte), folds the repair's fills in (`replace_filled`), passes the **same** merge gate (#1087, #1094), and emits only the touched shell at its shell path, so `overlay_artifacts` supersedes the failed shell by name and the retest runs it. Whole-shell rewrites dropped and recorded; `outputs["fill_merge"]` banks applied/rejected/dropped.

**Not exercised live** — this is the third safety net; the 1.6.4 set entered the loop twice and neither round reached a dev or fill repair. Prediction **Q4** is where it gets measured, and the plan's non-counting `lite` arm is the honest way to make it fire.

## Closes

Closes #970
Closes #969

## Evidence

- `test_qa_repair_fill_path.py`: one slot replaced and the touched shell alone emitted; a whole-shell rewrite dropped and recorded; a phantom-table repair fill rejected at the gate with the real table named; no-fill and no-current-shells paths say so; fill/file typing; `handle()` renders `qa_test_fill_mode_appendix` → `qa_test_repair_fill_appendix` → `cycle_repair_task` with the failed slot and reason in the addendum, and lands the merged shell in outputs; the addendum renders from the real asset.
- `test_correction_runner.py::TestQaRepairReachesFills`: fill observations read per (file, slot); own-artifact target = the failing slot's shell; without the scaffold the declared file as before; an app-contract failure never takes the branch; the envelope carries `current_files` (shell paths only) and `repair_slots`; presence-keyed (foreign role / no scaffold → nothing).
- `test_verification_scaffold_fill.py::TestRecoverFills`: round trip byte for byte across filled / not-applicable / missing; a repair may replace a filled slot, a self-eval may not.
- Regression after the last edit: **7,994 passed, 0 failed**, script exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tj9vAj9yumEzAmBLrZnrX
