### PR TITLE
fix(scaffold): the success-status default has one home — the skeleton pins what the contract asserts (#772)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ All notable changes to SquadOps are recorded here. Format loosely follows
   `config_overrides: {max_completion_tokens: 12288}`; four of ten qa primary emissions in that
   set sat at or within 3% of the 8,192 cap. The registry clamp (the V38 pin) and the dev
   budget are untouched. Changes `resolved_config_hash`; measured by prediction Q5.
+- **#772 — the success-status default has one home.** The contract deriver asserted 201 for an
+  undeclared collection POST while the stack #1 skeleton omitted `status_code=` and FastAPI
+  answered 200 — an unwinnable contract, gate-mitigated since 08-10 and never fixed. The rule
+  (`capabilities/success_status.py`: declared wins, else collection POST 201 / child POST 200,
+  else HTTP's 200) had seven homes — three deriver sites, the skeleton, the framing mirror, the
+  scaffold gate's allowed set, the Next.js route stub; every one now calls the seam, the
+  decorator pins the derived status too, and a structural test fails if a copy returns.
+  Reference fixtures unchanged (they declare their statuses).
 - **D — an own-artifact qa repair can reach a fill** (#970, with #969's brief). Under fill mode
   the shells are merge products, never in `expected_artifacts`, so the own-artifact repair aimed
   at the plan's declared file and a failing fill was structurally unreachable. Now: the target is

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -42,6 +42,10 @@ from squadops.capabilities.stack_nextjs_ts import expand_nextjs_ts as _expand_ne
 from squadops.capabilities.stack_nextjs_ts import (
     fill_slots_nextjs_ts as _fill_slots_nextjs_ts,
 )
+from squadops.capabilities.success_status import (  # noqa: F401 — re-exported: the seam's home
+    derived_success_status,
+    success_status_for,
+)
 
 # Schema v1 is frozen (SIP-0099 phase 99.1): the shape below is the canonical
 # interface-manifest contract the fullstack_fastapi_react expander was proven against
@@ -1426,9 +1430,16 @@ def _routes_source(manifest: InterfaceManifest) -> str:
         if ep.response:
             decorator += f", response_model={_py_type(ep.response)}"
         # The success status is *interface*, not implementation — it belongs to the
-        # scaffold-owned decorator so the fill dev cannot drop it (pf-39).
-        if ep.success_status is not None:
-            decorator += f", status_code={ep.success_status}"
+        # scaffold-owned decorator so the fill dev cannot drop it (pf-39). #772: an
+        # UNDECLARED status is pinned too, to the same default the contract asserts —
+        # an omitted kwarg meant FastAPI's 200 against the deriver's 201, unwinnable.
+        pinned = (
+            ep.success_status
+            if ep.success_status is not None
+            else derived_success_status(ep.method, ep.path)
+        )
+        if pinned is not None:
+            decorator += f", status_code={pinned}"
         decorator += ")"
         lines.append(decorator)
         lines.append(f"def {fn}({sig}):")

--- a/src/squadops/capabilities/scaffold_contract.py
+++ b/src/squadops/capabilities/scaffold_contract.py
@@ -34,6 +34,7 @@ from squadops.capabilities.scaffold import (
     criteria_pack_for,
     expand,
     fill_slot_paths,
+    success_status_for,
 )
 
 CONTRACT_VERSION = 1
@@ -467,7 +468,7 @@ def _probes(manifest: InterfaceManifest, pack: CriteriaPack) -> list[dict[str, A
             # the skeleton contradicted its own contract and only a dev agent
             # volunteering ``status_code=201`` could close the gap. A manifest that
             # declares no success status keeps the historical 201 expectation.
-            "expect": _success_expect(manifest, ep.success_status or 201, ep.response),
+            "expect": _success_expect(manifest, success_status_for(ep), ep.response),
         }
         probes.append(create_probe)
         # #593: the blank-input rejection probe. pf-38 volunteered blank-field
@@ -545,7 +546,7 @@ def _probes(manifest: InterfaceManifest, pack: CriteriaPack) -> list[dict[str, A
                         "subject": "backend",
                         "request": {"method": "POST", "path": child.path, "json": child_body},
                         "expect": _success_expect(
-                            manifest, child.success_status or 200, child.response
+                            manifest, success_status_for(child, "POST"), child.response
                         ),
                     }
                 )
@@ -605,7 +606,7 @@ def _probes(manifest: InterfaceManifest, pack: CriteriaPack) -> list[dict[str, A
                         "subject": "backend",
                         "request": {"method": "POST", "path": child.path, "json": child_body},
                         "expect": _success_expect(
-                            manifest, child.success_status or 200, child.response
+                            manifest, success_status_for(child, "POST"), child.response
                         ),
                     }
                 )

--- a/src/squadops/capabilities/stack_nextjs_ts.py
+++ b/src/squadops/capabilities/stack_nextjs_ts.py
@@ -35,6 +35,8 @@ import re
 from collections.abc import Collection
 from typing import TYPE_CHECKING, Any
 
+from squadops.capabilities.success_status import success_status_for
+
 if TYPE_CHECKING:  # pragma: no cover - annotations only, avoids a scaffold import cycle
     from squadops.capabilities.scaffold import InterfaceManifest
 
@@ -538,7 +540,7 @@ def _route_stub(path: str, endpoints: list[Any]) -> str:
     ]
     body = []
     for ep in endpoints:
-        status = getattr(ep, "success_status", None) or 200
+        status = success_status_for(ep)
         body += [
             f"export async function {ep.method.upper()}(request: Request) {{",
             "  try {",

--- a/src/squadops/capabilities/stack_nextjs_ts_tests.py
+++ b/src/squadops/capabilities/stack_nextjs_ts_tests.py
@@ -44,6 +44,7 @@ from typing import TYPE_CHECKING, Any
 from squadops.capabilities.response_shape import ResponseShape, derive_response_shape
 from squadops.capabilities.scaffold_contract import _slug
 from squadops.capabilities.stack_nextjs_ts import _segments
+from squadops.capabilities.success_status import success_status_for
 from squadops.capabilities.verification_scaffold import (
     BehaviorSlot,
     ScaffoldDerivationError,
@@ -306,7 +307,7 @@ def _minted_read_behaviors(
         if ep.method != "GET":
             continue
         placeholders = _placeholders(ep.path)
-        expect = ep.success_status or 200
+        expect = success_status_for(ep)
         if not placeholders:
             behaviors.append(
                 _Behavior(

--- a/src/squadops/capabilities/success_status.py
+++ b/src/squadops/capabilities/success_status.py
@@ -1,0 +1,38 @@
+"""The success status an endpoint answers with — the one home of the rule (#772, #1067).
+
+A leaf module on purpose: ``scaffold`` imports the stack modules at import time and the
+stack modules need this rule, so it cannot live in either without a cycle. ``scaffold``
+re-exports both names.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def derived_success_status(method: str, path: str) -> int | None:
+    """The success status the contract asserts for an endpoint that declares none.
+
+    Collection POST -> 201, child-action POST -> 200, everything else -> None (no status
+    probe is derived; a GET answers with HTTP's own 200). **The one home of this rule
+    (#772, #1067).** It had seven: three sites in the contract deriver, the skeleton's
+    decorator (which OMITTED the kwarg, so FastAPI's 200 met the deriver's 201 on an
+    undeclared collection POST — an unwinnable contract), the framing mirror, the
+    scaffold gate's allowed set and the Next.js route stub. Every one now calls here.
+    """
+    if method.upper() != "POST":
+        return None
+    return 201 if "{" not in path else 200
+
+
+def success_status_for(ep: Any, method: str | None = None) -> int:
+    """The status an implementer must answer with: declared wins, else derived, else 200.
+
+    ``method`` overrides the endpoint's own for child-action rows, which carry a path and
+    a declared status but are POSTs by construction.
+    """
+    declared = getattr(ep, "success_status", None)
+    if declared is not None:
+        return int(declared)
+    derived = derived_success_status(method or getattr(ep, "method", "GET"), ep.path)
+    return derived if derived is not None else 200

--- a/src/squadops/capabilities/verification_scaffold_gate.py
+++ b/src/squadops/capabilities/verification_scaffold_gate.py
@@ -79,12 +79,13 @@ def _declared_packages(tree: dict[str, str]) -> set[str]:
 
 
 def _allowed_statuses(manifest: InterfaceManifest) -> set[int]:
-    """Statuses the contract declares — the same defaults the probe deriver applies
-    (201 for a parameterless POST create, 200 otherwise), plus the error contract."""
+    """Statuses the contract declares — through the deriver's own seam (#772), plus the
+    error contract."""
     allowed: set[int] = set()
+    from squadops.capabilities.scaffold import success_status_for
+
     for ep in manifest.api.endpoints:
-        default = 201 if ep.method == "POST" and "{" not in ep.path else 200
-        allowed.add(ep.success_status or default)
+        allowed.add(success_status_for(ep))
     contract = manifest.api.error_contract
     for code in contract.codes if contract else ():
         allowed.add(code.http)

--- a/src/squadops/cycles/framing_consistency.py
+++ b/src/squadops/cycles/framing_consistency.py
@@ -61,17 +61,16 @@ _METHOD_TOKEN_RE = re.compile(r"\b(GET|POST|PUT|PATCH|DELETE)\b")
 def _enforced_success_status(ep: Endpoint) -> int | None:
     """The status the derived contract will actually assert for *ep*.
 
-    Mirrors ``scaffold_contract``'s derivation (collection POST → 201, child
-    POST → 200; see the deriver's ``ep.success_status or 201`` /
-    ``child.success_status or 200`` sites) — declared wins, defaults follow.
+    Reads ``scaffold.success_status_for`` — the one home of the rule (#772) —
+    so this cannot drift from what the deriver asserts: declared wins, defaults follow.
     GETs derive no status probe, so there is nothing to enforce and nothing to
     contradict.
     """
+    from squadops.capabilities.scaffold import success_status_for
+
     if ep.method.upper() != "POST":
         return ep.success_status  # declared-only for non-POST; None = unchecked
-    if ep.success_status is not None:
-        return ep.success_status
-    return 201 if "{" not in ep.path else 200
+    return success_status_for(ep)
 
 
 def path_pattern(path: str) -> re.Pattern[str]:

--- a/src/squadops/cycles/manifest_gates.py
+++ b/src/squadops/cycles/manifest_gates.py
@@ -420,7 +420,7 @@ def _testid_findings(manifest) -> list[WinnabilityFinding]:
 def _status_findings(manifest) -> list[WinnabilityFinding]:
     """A collection POST must declare its success status, or the contract is unwinnable.
 
-    Measured, not assumed (#772). The contract deriver expects ``success_status or 201``
+    Measured, not assumed (#772). The contract deriver expects the seam's 201
     for a collection POST, while the scaffold omits ``status_code=`` when it is
     undeclared — so FastAPI returns 200 and the probe asserts 201 against a correctly
     implemented app. The field's own docstring records this costing a roll at pf-39:
@@ -451,17 +451,11 @@ def _status_findings(manifest) -> list[WinnabilityFinding]:
 
 
 def derived_success_status(method: str, path: str) -> int | None:
-    """The status the contract deriver computes for an endpoint, ignoring declarations.
+    """The contract's default for an undeclared status — re-exported from the one home
+    of the rule (``capabilities.scaffold``, #772) so the gates keep their name for it."""
+    from squadops.capabilities.success_status import derived_success_status as _seam
 
-    Collection POST -> 201, child-action POST -> 200, everything else -> no status probe.
-    Single-sourced here because #1067 is a story about one fact having several homes:
-    `scaffold_contract` applies this rule at three sites (`ep.success_status or 201`,
-    `child.success_status or 200` twice) and `framing_consistency` mirrors it, and adding
-    a fourth copy to police the first three would be the same defect one layer up.
-    """
-    if method.upper() != "POST":
-        return None
-    return 201 if "{" not in path else 200
+    return _seam(method, path)
 
 
 def _status_override_findings(manifest) -> list[WinnabilityFinding]:

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -105,10 +105,13 @@ def test_expand_defines_every_declared_endpoint_and_model():
     routes = files["backend/routes.py"]
     assert '@router.get("/runs", response_model=list[RunEvent])' in routes
     # /runs declares success_status: 201, so the decorator carries it (pf-39); join
-    # declares none, so its decorator stays bare — the two together pin that the
-    # status is emitted from the manifest rather than blanket-applied.
+    # declares none, so its decorator carries the DERIVED 200 — the value the contract
+    # asserts for a child POST (#772: a bare decorator meant FastAPI's 200 met the
+    # deriver's 201 on an undeclared collection POST, an unwinnable contract). The two
+    # together pin that the status comes from the manifest or the deriver's one seam,
+    # never from a framework default the contract does not know about.
     assert '@router.post("/runs", response_model=RunEvent, status_code=201)' in routes
-    assert '@router.post("/runs/{run_id}/join", response_model=RunEvent)' in routes
+    assert '@router.post("/runs/{run_id}/join", response_model=RunEvent, status_code=200)' in routes
     assert "payload: RunEventCreate" in routes
     assert "payload: ParticipantName" in routes
     # only referenced models are imported (no unused-import lint failure)

--- a/tests/unit/capabilities/test_success_status_seam.py
+++ b/tests/unit/capabilities/test_success_status_seam.py
@@ -1,0 +1,102 @@
+"""One home for the success-status default — #772, the seventh site of a rule that
+recurred five times in three weeks (#1067).
+
+Bug caught: the contract deriver asserts 201 for an undeclared collection POST while the
+skeleton's decorator omits ``status_code`` and FastAPI answers 200 — a contract no
+correct application can win. It was gate-mitigated (an undeclared status is rejected at
+framing) and never fixed; on stack #1 it would have been a framing re-roll on every roll
+whose author forgot the line.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from squadops.capabilities.scaffold import InterfaceManifest, expand
+from squadops.capabilities.scaffold_contract import emit_contract_dict
+from squadops.capabilities.success_status import derived_success_status, success_status_for
+from squadops.cycles.verification_contract import VerificationContract
+from tests.unit.capabilities._stack_fixtures import manifest_dict_for_stack
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_SRC = Path(__file__).resolve().parents[3] / "src" / "squadops"
+
+
+class TestTheSeam:
+    @pytest.mark.parametrize(
+        "method, path, declared, expected",
+        [
+            ("POST", "/runs", None, 201),
+            ("POST", "/runs/{run_id}/join", None, 200),
+            ("POST", "/runs", 202, 202),
+            ("GET", "/runs", None, 200),
+            ("GET", "/runs", 203, 203),
+            ("DELETE", "/runs/{run_id}", None, 200),
+        ],
+    )
+    def test_declared_wins_then_derived_then_http_default(self, method, path, declared, expected):
+        ep = SimpleNamespace(method=method, path=path, success_status=declared)
+        assert success_status_for(ep) == expected
+
+    def test_derived_is_none_where_no_status_probe_exists(self):
+        assert derived_success_status("GET", "/runs") is None
+        assert derived_success_status("post", "/runs") == 201
+        assert derived_success_status("POST", "/runs/{id}/leave") == 200
+
+    def test_a_child_row_is_a_post_by_construction(self):
+        child = SimpleNamespace(path="/runs/{run_id}/join", success_status=None)
+        assert success_status_for(child, "POST") == 200
+
+
+def _undeclared_collection_post(stack: str) -> InterfaceManifest:
+    """The stack's reference manifest with the collection POST's status REMOVED."""
+    raw = manifest_dict_for_stack(stack)
+    for ep in raw["api"]["endpoints"]:
+        if ep["method"] == "POST" and "{" not in ep["path"]:
+            ep.pop("success_status", None)
+    return InterfaceManifest.from_yaml(yaml.safe_dump(raw, sort_keys=False))
+
+
+class TestSkeletonAndContractAgree:
+    def test_stack1_decorator_pins_the_status_the_contract_asserts(self):
+        """The #772 property, end to end: undeclared collection POST -> the derived
+        contract probe expects 201 AND the seeded decorator carries status_code=201."""
+        manifest = _undeclared_collection_post("fullstack_fastapi_react")
+        contract = VerificationContract.from_dict(emit_contract_dict(manifest))
+        create = next(p for p in contract.behavioral.probes if p.request.get("path") == "/runs")
+        assert create.expect["status"] == 201
+
+        routes = next(f["content"] for f in expand(manifest) if f["name"] == "backend/routes.py")
+        assert re.search(r'@router\.post\("/runs",[^\n]*status_code=201\)', routes), routes
+
+    def test_nextjs_stub_tells_the_dev_the_status_the_contract_asserts(self):
+        manifest = _undeclared_collection_post("nextjs_ts")
+        contract = VerificationContract.from_dict(emit_contract_dict(manifest))
+        create = next(p for p in contract.behavioral.probes if p.request.get("path") == "/api/runs")
+        route = next(f["content"] for f in expand(manifest) if f["name"] == "app/api/runs/route.ts")
+        assert create.expect["status"] == 201
+        assert "POST /api/runs — respond 201" in route
+
+
+def test_the_rule_has_no_second_home():
+    """Structural: a re-introduced ``success_status or 201`` / ``201 if ... else 200``
+    anywhere outside the seam is the defect this file exists to end."""
+    copies = []
+    pattern = re.compile(
+        r"success_status(?:\", None\))?\s+or\s+20[01]\b|\b201 if [^\n]* else 200\b"
+    )
+    for path in _SRC.rglob("*.py"):
+        if path.name == "success_status.py":
+            continue
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            if line.lstrip().startswith("#") or '"""' in line:
+                continue
+            if pattern.search(line):
+                copies.append(f"{path.relative_to(_SRC)}:{lineno}: {line.strip()}")
+    assert copies == [], "\n".join(copies)


### PR DESCRIPTION
## What

**#772**: the contract deriver asserts 201 for an undeclared collection POST while the stack #1 skeleton omits `status_code=` and FastAPI answers 200 — a contract no correct app can win. Gate-mitigated since 08-10 (`PROOF_STATUS_DECLARED` rejects the omission at framing) and never fixed; on stack #1, whose regression arm is next, that is a framing re-roll every time an author forgets the line.

The rule had **seven homes**: `scaffold_contract.py:470/548/608` (`or 201` / `or 200` ×2), the skeleton decorator (omission), `framing_consistency._enforced_success_status` (mirror), `verification_scaffold_gate._allowed_statuses`, `stack_nextjs_ts.py:541` (route stub told the dev "respond 200" on an undeclared collection POST the contract probes at 201), and the nextjs GET shells. `manifest_gates.derived_success_status`'s own docstring said adding a copy to police the others "would be the same defect one layer up".

**Now:** `capabilities/success_status.py` is the one home — a leaf module (`scaffold` imports the stack modules at import time and they need the rule, so neither can own it without a cycle); `scaffold` re-exports it and `manifest_gates` keeps its name. `derived_success_status()` / `success_status_for()`: declared wins, else collection POST 201 / child POST 200, else HTTP's 200. Every site calls it. The skeleton decorator pins the **derived** status too, so the seeded join route reads `status_code=200` — the old pin ("stays bare") updated with the reason.

**Fixtures:** unchanged — the reference manifests declare their statuses; contract v9/v10 and the nextjs scaffold hash hold (the reference suites pass untouched).

## Closes

Closes #772

## Evidence

- `test_success_status_seam.py` (11): the seam's cases (declared / collection / child / GET / DELETE); **the #772 property end to end on stack #1** — the reference manifest with the collection POST's status removed: contract probe expects 201 **and** the seeded decorator carries `status_code=201`; the nextjs stub tells the dev "respond 201" for the same case; **a structural guard** that greps `src/` for `success_status or 20x` / `201 if … else 200` outside the seam and fails on any hit.
- Regression after the last edit: see below; the CI skeleton gate boots the changed stack #1 skeleton.

Regression after the last edit: **7981 passed, 0 failed**, script exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tj9vAj9yumEzAmBLrZnrX
