### PR TITLE
fix(correction): the failed task's own artifact never narrows the repair target (#1120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ All notable changes to SquadOps are recorded here. Format loosely follows
   scaffold gate's allowed set, the Next.js route stub; every one now calls the seam, the
   decorator pins the derived status too, and a structural test fails if a copy returns.
   Reference fixtures unchanged (they declare their statuses).
+- **#1120 — a qa-side failure no longer empties the dev repair target.** The analyzer half of
+  #1015-A let the failed task's *own* artifact (a free-authored frontend suite the analyzer
+  honestly implicated) act as a narrowing site: the language-wide surface was withheld, the #884
+  veto removed the qa-owned file from the dev-role target, and every round was dispatched with
+  nothing to produce and refunded — found on the first stack #1 cycle since 08-09
+  (`cyc_3cde35fa5204`). Own artifacts ride the target but never narrow it; the package-scoped
+  surface applies as it did before the analyzer half shipped.
 - **D — an own-artifact qa repair can reach a fill** (#970, with #969's brief). Under fill mode
   the shells are merge products, never in `expected_artifacts`, so the own-artifact repair aimed
   at the plan's declared file and a failing fill was structurally unreachable. Now: the target is

--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -501,6 +501,21 @@ def _resolve_repair_target(
     analysis_files = (
         _verified_implicated_files(failure_analysis, failed_inputs) if not probe_slots else []
     )
+    # #1120: the failed task's OWN artifacts are never a narrowing site. They already ride
+    # the target as failed_artifacts and the ownership veto (#884) decides who may touch
+    # them; letting one of them withhold the language-wide surface left a dev-role
+    # repair of a qa-side failure with an EMPTY target (stack #1, cyc_3cde35fa5204:
+    # the analyzer named the failing jsx suite, the veto removed it, every round was
+    # refunded). Sites that narrow are files someone else owns.
+    own = {str(f) for f in failed_artifacts}
+    own_only = [f for f in analysis_files if f in own]
+    analysis_files = [f for f in analysis_files if f not in own]
+    if own_only and not analysis_files:
+        logger.info(
+            "correction_repair_target: the analyzer implicated only the failed task's own "
+            "artifact(s) %s — not a narrowing site; the surface is what it was (#1120)",
+            ", ".join(own_only),
+        )
     scoped_source = _narrowed_or_scoped(
         [*probe_slots, *analysis_files], failed_inputs, failed_artifacts
     )

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -4856,3 +4856,84 @@ class TestQaRepairReachesFills:
             role, self._inputs(with_scaffold=with_scaffold), MagicMock(outputs={}), self._evidence()
         )
         assert out == {}
+
+
+class TestOwnArtifactNeverNarrows:
+    """#1120: a dev-role repair of a qa-side failure must not be handed an empty target.
+
+    Replays the 1.6.5 stack #1 shakeout (cyc_3cde35fa5204): a free-authored frontend
+    suite fails with no probe and no drift; the analyzer implicates the suite file itself.
+    Before this, that file narrowed the target, the #884 veto removed it, and the dev
+    repair emitted nothing on every round.
+    """
+
+    INPUTS = {
+        "expected_artifacts": ["frontend/src/__tests__/runs.test.jsx"],
+        "implementation_artifacts": [
+            "backend/routes.py",
+            "frontend/src/views/RunsListView.jsx",
+            "frontend/src/views/CreateRunView.jsx",
+            "frontend/src/views/RunDetailView.jsx",
+        ],
+    }
+    SUITE_FAIL = {
+        "validation_result": {
+            "passed": False,
+            "checks": [{"check": "tests_pass", "status": "failed"}],
+        }
+    }
+
+    def test_the_own_artifact_rides_but_does_not_narrow(self):
+        from adapters.cycles.correction_runner import _apply_ownership_veto, _resolve_repair_target
+
+        target, _, _ = _resolve_repair_target(
+            self.SUITE_FAIL,
+            dict(self.INPUTS),
+            {"implicated_files": ["frontend/src/__tests__/runs.test.jsx"]},
+        )
+        # the package-scoped surface is back: the frontend views under test
+        assert {
+            "frontend/src/views/RunsListView.jsx",
+            "frontend/src/views/CreateRunView.jsx",
+            "frontend/src/views/RunDetailView.jsx",
+        } <= set(target)
+        assert "backend/routes.py" not in target  # package scoping still bounds the radius
+        assert "frontend/src/__tests__/runs.test.jsx" in target  # pf-21: it still rides
+        # and after the dev-role veto the target is NOT empty — the exact failure
+        dev_target = _apply_ownership_veto(
+            target, "qa.test", "dev", self.INPUTS["expected_artifacts"]
+        )
+        assert dev_target and "frontend/src/__tests__/runs.test.jsx" not in dev_target
+
+    def test_a_foreign_implicated_file_still_narrows(self):
+        """The #1015-A analyzer half is untouched where it belongs: a claim on a file
+        someone else owns narrows exactly as before."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        target, _, _ = _resolve_repair_target(
+            self.SUITE_FAIL,
+            dict(self.INPUTS),
+            {"implicated_files": ["frontend/src/views/RunDetailView.jsx"]},
+        )
+        assert target == [
+            "frontend/src/views/RunDetailView.jsx",
+            "frontend/src/__tests__/runs.test.jsx",
+        ]
+
+    def test_own_and_foreign_together_narrow_on_the_foreign_file_only(self):
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        target, _, _ = _resolve_repair_target(
+            self.SUITE_FAIL,
+            dict(self.INPUTS),
+            {
+                "implicated_files": [
+                    "frontend/src/__tests__/runs.test.jsx",
+                    "frontend/src/views/RunsListView.jsx",
+                ]
+            },
+        )
+        assert target == [
+            "frontend/src/views/RunsListView.jsx",
+            "frontend/src/__tests__/runs.test.jsx",
+        ]


### PR DESCRIPTION
## What

Found by the 1.6.5 **stack #1 regression shakeout** (`cyc_3cde35fa5204`) — the first cycle on `fullstack_fastapi_react` since 08-09 — on its second identical correction round. A free-authored frontend suite (`frontend/src/__tests__/runs.test.jsx`, 5/8 failing on DOM expectations the views do not meet) fails with **no HTTP probe and no drift**, so the resolver takes the analyzer half of #1015-A (v1.6.4, #1100). The analyzer honestly implicates the suite file itself; `_verified_implicated_files` keeps it (it is the task's own expected artifact); `_narrowed_or_scoped` treats it as a defect site and withholds the language-wide surface; the #884 veto then strips the qa-owned file from the dev-role target — **empty target**, empty emission, refunded round, byte-identical next round (runtime-api log lines in #1120).

**Fix** (`correction_runner.py`, the analyzer-half block): the failed task's own artifacts are never a *narrowing* site — they already ride via `failed_artifacts` and the veto decides who may touch them. They are excluded from `analysis_files`; when nothing remains, the package-scoped surface applies exactly as before v1.6.4 (the frontend views enter the target), and the own-artifact-only case is logged for the locus classifier. A foreign implicated file narrows as before.

## Closes

Closes #1120

## Evidence

- `TestOwnArtifactNeverNarrows` (3): the replay shape — own artifact rides, views enter, backend stays out (package scoping), and **the dev-role target after the veto is non-empty**; a foreign implicated file still narrows; own + foreign → narrows on the foreign file only. The existing #1015-A analyzer tests are untouched and pass.
- Regression after the last edit: **8027 passed, 0 failed** (the first run tripped the CHANGELOG rotation guard on a version string in the entry — reworded, re-run), script exit 0. (CI will queue until the GitHub Actions incident clears.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tj9vAj9yumEzAmBLrZnrX
