### PR TITLE
fix(scaffold): an optional entity field with a declared null default freezes nullable (#1125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ All notable changes to SquadOps are recorded here. Format loosely follows
 
 ## [Unreleased]
 
-Nothing yet.
+### 1.6.6 line — the React arm's round-0 defects (plan: `docs/plans/1-6-6-plan.md`)
+
+- **A — an optional entity field freezes nullable** (#1125). A manifest field declared
+  `required: false, default: null` froze as `distance: str = None` — a non-nullable annotation
+  with a `None` default — because the declared null set `has_default` and the nullable branch
+  only fired when no default key existed; the request shape was correctly `str | None`, so the
+  route forwarded the request's `None` into the entity and pydantic answered 500 on POST /runs.
+  Five of the six FastAPI+React rolls in the previous set opened with that failure; the three
+  manifests that omitted the key were clean. The rule now: a declared null default and an
+  optional field with no default both freeze `X | None = None`; a non-null default keeps
+  `X = default`. Python emitter only — the TS emitter renders `distance?: string` and is
+  untouched; every pinned fixture (the Next.js reference scaffold, the stack-#1 contract
+  reference, the context goldens) is byte-identical.
 
 ## [1.6.5] — 2026-08-27
 

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -1334,9 +1334,15 @@ def _model_source(manifest: InterfaceManifest) -> str:
                 lines.append(f"    {f.name}: {ann}")
             elif f.has_default and isinstance(f.default, list):
                 lines.append(f"    {f.name}: {ann} = Field(default_factory=list)")
-            elif f.has_default:
+            elif f.has_default and f.default is not None:
                 lines.append(f"    {f.name}: {ann} = {f.default!r}")
             else:
+                # #1125: a declared ``default: null`` and an optional field with no default
+                # mean the same thing — the value may be absent — and both freeze nullable.
+                # ``default: null`` used to take the branch above and emit ``str = None``:
+                # a non-nullable annotation with a None default, which pydantic v2 rejects
+                # (``string_type``) the moment a route forwards the request's None into the
+                # model. Five of six 1.6.5 FastAPI+React rolls paid that as a round-0 500.
                 lines.append(f"    {f.name}: {ann} | None = None")
         lines.append("")
 

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -834,6 +834,84 @@ class TestFrontendTestHarness:
         assert "frontend/src/test-setup.js" not in slots
 
 
+class TestFrozenModelOptionalFields:
+    """#1125: what the frozen pydantic model says about a field the manifest marks
+    optional. Five of six 1.6.5 FastAPI+React rolls opened with a 500 on POST /runs
+    because ``required: false, default: null`` froze as ``distance: str = None`` —
+    pydantic v2 rejects an explicit None for a ``str`` field — while the request
+    shape was correctly nullable and the route forwarded its None straight in."""
+
+    @staticmethod
+    def _run_field_line(field: dict) -> str:
+        raw = _raw_manifest()
+        run = next(e for e in raw["entities"] if e["name"] == "RunEvent")
+        run["fields"] = [f for f in run["fields"] if f["name"] != "distance"] + [field]
+        models = _by_name(expand(InterfaceManifest.from_dict(raw)))["backend/models.py"]
+        compile(models, "backend/models.py", "exec")
+        klass = models.split("class RunEvent(BaseModel):", 1)[1].split("\nclass ", 1)[0]
+        return next(ln.strip() for ln in klass.splitlines() if ln.strip().startswith("distance:"))
+
+    @pytest.mark.parametrize(
+        ("field", "expected"),
+        [
+            # the 1.6.5 shape: a declared null default is nullable, not ``str = None``
+            (
+                {"name": "distance", "type": "string", "required": False, "default": None},
+                "distance: str | None = None",
+            ),
+            # the shakeouts' shape: optional with no default key — same meaning, same line
+            (
+                {"name": "distance", "type": "string", "required": False},
+                "distance: str | None = None",
+            ),
+            # a non-null default is never None after construction, so it stays non-nullable
+            (
+                {"name": "distance", "type": "string", "required": False, "default": "5k"},
+                "distance: str = '5k'",
+            ),
+            # a required field without a default is a bare annotation
+            (
+                {"name": "distance", "type": "string", "required": True},
+                "distance: str",
+            ),
+        ],
+        ids=["default-null", "no-default", "non-null-default", "required"],
+    )
+    def test_optional_field_freezes_by_its_effective_default(self, field, expected):
+        assert self._run_field_line(field) == expected
+
+    def test_null_default_model_accepts_the_request_shapes_none(self):
+        """The failure as the app saw it: the route builds the entity from an optional
+        request field that is None. With the old emission this raised ValidationError."""
+        import sys
+        import types
+
+        raw = _raw_manifest()
+        run = next(e for e in raw["entities"] if e["name"] == "RunEvent")
+        for f in run["fields"]:
+            if f["name"] in ("distance", "pace_target", "route_notes"):
+                f["default"] = None
+        models = _by_name(expand(InterfaceManifest.from_dict(raw)))["backend/models.py"]
+        # The emitted module uses ``from __future__ import annotations``; pydantic
+        # resolves the entity references through ``sys.modules[cls.__module__]``.
+        mod = types.ModuleType("frozen_models_1125")
+        sys.modules[mod.__name__] = mod
+        try:
+            exec(compile(models, "backend/models.py", "exec"), mod.__dict__)
+            run_event = mod.RunEvent(
+                id="r1",
+                title="t",
+                datetime="2026-08-01T08:00:00",
+                location="here",
+                distance=None,
+                pace_target=None,
+                route_notes=None,
+            )
+        finally:
+            del sys.modules[mod.__name__]
+        assert (run_event.distance, run_event.pace_target, run_event.route_notes) == (None,) * 3
+
+
 class TestNonBlankRequestFields:
     """#593: the emitted request models must actually enforce the constraint —
     a template typo (wrong alias, misplaced annotation) would compile fine and


### PR DESCRIPTION
## Summary

**1.6.6 item A (#1125).** A manifest field declared `required: false, default: null` froze as `distance: str = None` — a non-nullable annotation with a `None` default — because the declared null set `has_default` (`scaffold.py:486`) and the nullable branch only fired when no default key existed (`:1332-1340`). The request shape was correctly `str | None`, so the route forwarded the request's `None` into `Run(...)` and pydantic answered 500 on POST /runs. Five of the six FastAPI+React rolls in the 1.6.5 set opened with that failure; the three manifests without the key were clean.

**The rule (owner's ruling, narrow):** a declared null default and an optional field with no default both freeze `X | None = None`; a non-null default keeps `X = default` (never `None` after construction); a required field stays a bare annotation.

**Stack safety — checked, not asserted:** `_model_source` is reached only from `_expand_fullstack_fastapi_react` (`scaffold.py:1851`); the TS emitter renders `distance?: string` and is untouched. **Every pinned fixture is byte-identical** — the Next.js reference scaffold (`test_verification_scaffold_reference.py`), the stack-#1 contract reference (`test_contract_derivation_reference.py`, the reference manifest writes `required: false` with no default), the stack-#1 hash in `test_stack_nextjs_ts.py`, and the three context goldens. No GENERATOR_VERSION change.

## Tests

- `TestFrozenModelOptionalFields` — parametrized over the four shapes (`default: null`, no default, non-null default, required) asserting the exact emitted line, plus the failure as the app saw it: the emitted module accepts `Run(distance=None, …)`. Against the old emitter: 3 fail / 3 pass (verified by stashing the source change).
- `./scripts/dev/run_regression_tests.sh` — 8039 passed, 1 skipped, exit 0.

Item B (#1127, the harness cleanup) is on its own PR: it moves the stack-#1 contract reference and the context goldens and needs the pin classification cleared first.

## Closes

Closes #1125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tj9vAj9yumEzAmBLrZnrX
