### PR TITLE
fix(correction): the passing retest's evidence is what the repaired task stores (#1111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to SquadOps are recorded here. Format loosely follows
   stack-#1 contract reference (v10 → v11, `reference_defect` per the M0 taxonomy: a harness
   that can only reject a working app, never pass a broken one, so the 1.4 figure carries no
   qualification) and the three context goldens' `frozen_surface_index` line for that file.
+- **F — the passing retest is what the qa task stores** (#1111). An accepted patch re-stored
+  the failed result's artifacts overlaid with the repair, so the failed run's `test_report.md`
+  and typed-check evaluation landed under the task id seconds *after* the retest banked its
+  passing report under its own — and on FastAPI+React roll 1 the next analysis read the
+  failure and sent a repair at a file the loop had already fixed. Evidence artifacts in the
+  re-store are now replaced by the passing retest's same-named artifact or dropped; work
+  product is untouched and the retest's own suite files stay under the retest id.
 
 ## [1.6.5] — 2026-08-27
 

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -71,6 +71,7 @@ from squadops.cycles.patch_verification import (
     PATCH_UNVERIFIABLE,
     STRUCTURALLY_UNEVALUABLE_REASONS,
     overlay_artifacts,
+    supersede_evidence_artifacts,
     verify_patched_artifacts,
 )
 from squadops.cycles.rejection_baseline import (
@@ -3210,6 +3211,22 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 retest_rows = [
                     row for row in retest_validation.get("checks", []) if isinstance(row, dict)
                 ]
+            # #1111: the passing retest is what the task stores. Without this the
+            # failed run's test_report.md and typed-check evaluation were re-stored
+            # under the task id seconds AFTER the retest banked its passing report —
+            # and the next analysis read the failure (1.6.5 FastAPI+React roll 1).
+            supersession = supersede_evidence_artifacts(
+                patched_artifacts, retest_outputs.get("artifacts")
+            )
+            patched_artifacts = supersession.artifacts
+            if supersession.replaced or supersession.dropped:
+                logger.info(
+                    "patch_retest task=%s evidence superseded by the passing retest: "
+                    "replaced=%s dropped=%s (#1111)",
+                    envelope.task_id,
+                    ",".join(supersession.replaced) or "-",
+                    ",".join(supersession.dropped) or "-",
+                )
 
         corrected_outputs["artifacts"] = patched_artifacts
         prior_validation = corrected_outputs.get("validation_result")

--- a/src/squadops/cycles/patch_verification.py
+++ b/src/squadops/cycles/patch_verification.py
@@ -158,6 +158,61 @@ def overlay_artifacts(
     return list(merged.values())
 
 
+#: Artifact types that are EVIDENCE about a task's own run — a report of what the
+#: suite did, a typed-check evaluation — rather than work product. They describe one
+#: execution and are wrong the moment a later execution of the same task supersedes it.
+EVIDENCE_ARTIFACT_TYPES: frozenset[str] = frozenset({"test_report", "typed_check_evaluation"})
+
+
+@dataclass(frozen=True)
+class EvidenceSupersession:
+    """What :func:`supersede_evidence_artifacts` did, for the log line."""
+
+    artifacts: list[dict[str, Any]]
+    replaced: tuple[str, ...] = ()
+    dropped: tuple[str, ...] = ()
+
+
+def supersede_evidence_artifacts(
+    patched: list[dict[str, Any]] | None, retest_artifacts: list[dict[str, Any]] | None
+) -> EvidenceSupersession:
+    """After a PASSING retest, the failed task's own evidence must not be re-stored (#1111).
+
+    An accepted patch re-stores ``patched`` under the repaired task's id. That list is the
+    failed result's artifacts overlaid with the repair — so it still carries the failed run's
+    ``test_report.md`` and ``typed_check_evaluation_*.json``, written seconds after the retest
+    stored its passing report under its own id. Last-writer-wins: the first artifact a triage
+    opens for the task says the tests failed on a run whose verdict is ``accepted``, and on
+    1.6.5 FastAPI+React roll 1 the next round's analyzer read exactly that and re-diagnosed a
+    defect the repair had already fixed.
+
+    Evidence artifacts (:data:`EVIDENCE_ARTIFACT_TYPES`) in ``patched`` are replaced by the
+    retest's same-named artifact when it produced one, and dropped otherwise — the corrected
+    result carries the retest's fresh ``test_result`` and validation rows, so a stale
+    evaluation file adds nothing but the wrong answer. Work product is untouched, and the
+    retest's own suite files are never added here: they are stored under the retest's id.
+    """
+    fresh: dict[str, dict[str, Any]] = {}
+    for art in retest_artifacts or []:
+        name = art.get("name")
+        if isinstance(name, str) and name and art.get("type") in EVIDENCE_ARTIFACT_TYPES:
+            fresh[name] = art
+    kept: list[dict[str, Any]] = []
+    replaced: list[str] = []
+    dropped: list[str] = []
+    for art in patched or []:
+        if art.get("type") not in EVIDENCE_ARTIFACT_TYPES:
+            kept.append(art)
+            continue
+        name = art.get("name")
+        if isinstance(name, str) and name in fresh:
+            kept.append(fresh[name])
+            replaced.append(name)
+        else:
+            dropped.append(str(name))
+    return EvidenceSupersession(kept, tuple(replaced), tuple(dropped))
+
+
 @dataclass(frozen=True)
 class MaterializeResult:
     """Outcome of a unified ``materialize`` (SIP-0100 2.2)."""

--- a/tests/unit/cycles/test_outcome_routing.py
+++ b/tests/unit/cycles/test_outcome_routing.py
@@ -666,6 +666,49 @@ class TestAcceptPatchRetest:
         patched = call.args[3]
         by_name = {a["name"]: a["content"] for a in patched}
         assert "assert 1" in by_name["tests/test_api.py"]
+        # #1111: the retest produced no report of its own, so the FAILED run's
+        # test_report.md is dropped from what the task re-stores — never re-stored
+        # in its failed form beside a passing retest.
+        stored = {a["name"]: a for a in corrected.outputs["artifacts"]}
+        assert "test_report.md" not in stored
+        assert "assert 1" in stored["tests/test_api.py"]["content"]
+
+    async def test_passing_retest_report_is_what_the_task_stores(self, executor, cycle):
+        """Bug caught (#1111, 1.6.5 FastAPI+React roll 1 `cyc_b9296c255dfc`): at 03:15:08Z
+        the retest stored its passing report under its own id and, 20 ms later, the
+        accepted patch re-stored the task's FAILED test_report.md and typed-check
+        evaluation under the task id. The next analysis read the failure and sent
+        round 1 at a file the repair had already fixed."""
+        retest = self._retest_success()
+        retest.outputs["artifacts"] = [
+            {
+                "name": "tests/test_api.py",
+                "content": "def test_x():\n    assert 1\n",
+                "type": "test",
+            },
+            {"name": "test_report.md", "content": "11 passed", "type": "test_report"},
+        ]
+        executor._correction_runner.reexecute_repaired_suite = AsyncMock(return_value=retest)
+        failed = self._failed_qa_result()
+        failed.outputs["artifacts"].append(
+            {
+                "name": "typed_check_evaluation_task_9.json",
+                "content": '{"passed": false}',
+                "type": "typed_check_evaluation",
+            }
+        )
+        holder: dict = {}
+        action = await executor._try_accept_patch(
+            self._qa_envelope(), failed, self._repair(), holder, **self._kwargs(cycle)
+        )
+
+        assert action == "accept_patch"
+        stored = {a["name"]: a for a in holder["patched_result"].outputs["artifacts"]}
+        assert stored["test_report.md"]["content"] == "11 passed"
+        assert "typed_check_evaluation_task_9.json" not in stored
+        # Work product is the repaired suite; the retest's copy is not added twice.
+        assert list(stored) == ["tests/test_api.py", "test_report.md"]
+        assert "assert 1" in stored["tests/test_api.py"]["content"]
 
     async def test_retest_failure_falls_back_to_continue(self, executor, cycle):
         """Bug caught: accepting a repair whose suite still fails when

--- a/tests/unit/cycles/test_patch_verification.py
+++ b/tests/unit/cycles/test_patch_verification.py
@@ -10,7 +10,9 @@ from squadops.cycles.patch_verification import (
     PATCH_FAILED,
     PATCH_PASSED,
     PATCH_UNVERIFIABLE,
+    EvidenceSupersession,
     overlay_artifacts,
+    supersede_evidence_artifacts,
     verify_patched_artifacts,
 )
 
@@ -211,6 +213,63 @@ def test_rehomed_repair_supersedes_in_overlay():
     )
     merged = {a["name"]: a["content"] for a in overlay_artifacts(base, patches)}
     assert merged == {"backend/routes.py": "fixed"}
+
+
+class TestSupersedeEvidenceArtifacts:
+    """#1111: an accepted patch re-stores the failed result's artifacts overlaid with the
+    repair — so the failed run's own evidence (report, typed-check evaluation) landed under
+    the task id AFTER the passing retest stored its report under its own id."""
+
+    _PATCHED = [
+        {"name": "backend/routes.py", "content": "fixed", "type": "source"},
+        {"name": "backend/tests/test_runs.py", "content": "tests", "type": "test"},
+        {"name": "test_report.md", "content": "3 validation errors for Run", "type": "test_report"},
+        {
+            "name": "typed_check_evaluation_task_4.json",
+            "content": "{}",
+            "type": "typed_check_evaluation",
+        },
+    ]
+
+    def test_retest_report_replaces_the_failed_one_and_stale_evaluation_is_dropped(self):
+        retest = [
+            {"name": "backend/tests/test_runs.py", "content": "tests", "type": "test"},
+            {"name": "test_report.md", "content": "11 passed in 0.05s", "type": "test_report"},
+        ]
+        out = supersede_evidence_artifacts(self._PATCHED, retest)
+        assert [(a["name"], a["content"]) for a in out.artifacts] == [
+            ("backend/routes.py", "fixed"),
+            ("backend/tests/test_runs.py", "tests"),
+            ("test_report.md", "11 passed in 0.05s"),
+        ]
+        assert out.replaced == ("test_report.md",)
+        assert out.dropped == ("typed_check_evaluation_task_4.json",)
+
+    def test_retest_without_evidence_drops_the_failed_evidence(self):
+        out = supersede_evidence_artifacts(self._PATCHED, [])
+        assert [a["name"] for a in out.artifacts] == [
+            "backend/routes.py",
+            "backend/tests/test_runs.py",
+        ]
+        assert out.replaced == ()
+        assert out.dropped == ("test_report.md", "typed_check_evaluation_task_4.json")
+
+    def test_retest_work_product_is_never_added_and_non_evidence_is_never_touched(self):
+        """The retest's own suite files live under the retest id; a retest artifact
+        that only shares a NAME with work product must not overwrite it here."""
+        retest = [
+            {"name": "backend/routes.py", "content": "retest copy", "type": "source"},
+            {"name": "frontend/extra.test.jsx", "content": "new", "type": "test"},
+        ]
+        out = supersede_evidence_artifacts(self._PATCHED, retest)
+        by_name = {a["name"]: a["content"] for a in out.artifacts}
+        assert by_name["backend/routes.py"] == "fixed"
+        assert "frontend/extra.test.jsx" not in by_name
+        assert out.dropped == ("test_report.md", "typed_check_evaluation_task_4.json")
+
+    def test_empty_inputs(self):
+        out = supersede_evidence_artifacts(None, None)
+        assert out == EvidenceSupersession([], (), ())
 
 
 def test_exact_expected_path_passes_through():


### PR DESCRIPTION
## Summary

**1.6.6 item F (#1111).** After a passing retest, an accepted patch re-stored the failed result's artifacts overlaid with the repair — so the failed run's `test_report.md` and `typed_check_evaluation_*.json` landed under the task id **20 ms after** the retest banked its passing report under its own id (1.6.5 FastAPI+React roll 1 `cyc_b9296c255dfc`, 03:15:08Z: `art_510d1dfe170d` retest PASS at .893, `art_bfe3c5431a40` task FAIL re-store at .913, same content hash as the original failure). The next analysis (`art_6f7eba3677f1`) read the failure first and narrowed round 1's repair to `backend/routes.py` — a file the loop had already fixed. Filed as a record nit on 08-26; the set showed it steering the loop.

**Fix.** `supersede_evidence_artifacts` in `src/squadops/cycles/patch_verification.py`, beside `overlay_artifacts` (the seam that owns the re-store shape): evidence artifacts (`test_report`, `typed_check_evaluation`) in the re-store are replaced by the passing retest's same-named artifact when it produced one, and dropped otherwise — the corrected result already carries the retest's fresh `test_result` and validation rows. Work product is untouched; the retest's own suite files are never added (they live under the retest id). One call in `_try_accept_patch`, with a log line naming what was replaced/dropped.

## Tests

- `TestSupersedeEvidenceArtifacts` (pure): replace + drop with roll 1's artifact shapes; retest without evidence drops the failed evidence; retest work product never overwrites or adds; empty inputs.
- `test_passing_retest_report_is_what_the_task_stores` on `_try_accept_patch`: the corrected result's artifacts carry the retest's report, not the failed one, and no stale typed-check evaluation; the existing retest-pass test now also asserts the failed report is not re-stored.
- `./scripts/dev/run_regression_tests.sh` — 8045 passed, 1 skipped, exit 0.

## Closes

Closes #1111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tj9vAj9yumEzAmBLrZnrX
