### PR TITLE
fix(qa): the self-mocking detector judges through the stack's own definition of invoking the app (#1126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ All notable changes to SquadOps are recorded here. Format loosely follows
   failure and sent a repair at a file the loop had already fixed. Evidence artifacts in the
   re-store are now replaced by the passing retest's same-named artifact or dropped; work
   product is untouched and the retest's own suite files stay under the retest id.
+- **C — "invokes the application" is the stack's own definition** (#1126). The
+  self-mocking detector defined it as an `app/api/` import — the Next.js in-process model —
+  inside a shared module, and failed a green FastAPI+React suite that rendered the real `App`
+  with `fetch` stubbed while passing the one that `vi.mock`ed the app's own API client. Each
+  `ScaffoldStack` now declares an `AppInvocation` (the import that proves the app is invoked,
+  the mock that replaces the subject, the mock that replaces the network seam) in a leaf
+  module; the detector only applies it, resolved through `app_invocation_for` beside
+  `check_stack_for`. On React a rendered component or `App` invokes the app and a `fetch`
+  stub or `api.js` mock under it is legitimate; mocking a view or `App` module is mocking
+  the subject. An unregistered stack is judged not at all and its row is banked with an
+  empty inspected inventory, never as clean. The discarded roll-1 suite is the replay test.
 
 ## [1.6.5] — 2026-08-27
 

--- a/src/squadops/capabilities/app_invocation.py
+++ b/src/squadops/capabilities/app_invocation.py
@@ -1,0 +1,59 @@
+"""How a suite on one stack reaches the application — the stack's fact (#1126).
+
+A leaf module, like ``success_status``: the stack modules declare an
+:class:`AppInvocation` and the qa-side detector applies it, and neither may import the
+other's package to do so (``handlers/__init__`` pulls in the handler tree, and the
+stack registry is imported by handlers).
+
+The self-mocking rule is stack-neutral: *a suite that replaces the seam it would reach the
+app through, and never invokes the app, verifies nothing.* What "invokes the app" looks
+like is not. Under Next.js's in-process model (#877) it is an import of an ``app/api/``
+route module; on a React SPA it is rendering a real component or ``App``, and a global
+``fetch`` stub is the *correct* way to isolate the network under it. The first definition
+was written into the shared detector as if it were universal, and on 2026-08-27 it failed
+a green FastAPI+React suite that rendered the real ``App`` with ``fetch`` stubbed — while
+passing the suite that ``vi.mock``ed the app's own API module. Each stack now declares its
+own three patterns on its ``ScaffoldStack``; the detector only applies them.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+#: Replacing the network seam — the stack-neutral half. Stubbing ``fetch`` is the same act
+#: in every JS stack; what it MEANS is the stack's declaration below.
+NETWORK_SEAM_FETCH_STUB = r"""(?x)
+      global(?:This)?\s*\.\s*fetch\s*=                          # global.fetch = ...
+    | (?:vi|jest)\s*\.\s*stubGlobal\s*\(\s*['"`]fetch['"`]      # vi.stubGlobal('fetch', ...)
+    | (?:vi|jest)\s*\.\s*spyOn\s*\(\s*global(?:This)?\s*,\s*['"`]fetch['"`]
+"""
+
+
+@dataclass(frozen=True)
+class AppInvocation:
+    """The three patterns one stack needs to judge a self-mocking suite.
+
+    All three are regex *sources*, applied with ``re.MULTILINE`` so an import can be
+    required as a statement (``^\\s*import …``) rather than as any occurrence of a path —
+    a ``vi.mock('…/app/api/…')`` string must never satisfy the invocation test.
+    """
+
+    #: A real import of the application — the evidence that the suite invokes it.
+    invocation_import: str
+    #: A mock of the subject itself. Unconditional: there is no reading under which
+    #: replacing the module under test and asserting on it verifies that module.
+    subject_mock: str
+    #: Replacing the seam the suite would otherwise reach the app through. Flagged only
+    #: when nothing invokes the app — mocking is not the defect, mocking INSTEAD of
+    #: invoking is.
+    network_seam_mock: str = NETWORK_SEAM_FETCH_STUB
+
+    def invokes(self, content: str) -> bool:
+        return re.search(self.invocation_import, content, re.MULTILINE) is not None
+
+    def mocks_subject(self, content: str) -> bool:
+        return re.search(self.subject_mock, content, re.MULTILINE) is not None
+
+    def mocks_network(self, content: str) -> bool:
+        return re.search(self.network_seam_mock, content, re.MULTILINE) is not None

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -11,6 +11,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from squadops.capabilities.app_invocation import AppInvocation
 from squadops.capabilities.dev_capabilities import (
     DEFAULT_DEV_CAPABILITY,
     effective_capability_name,
@@ -426,6 +427,17 @@ class QATestHandler(_CycleTaskHandler):
             "type": "test_report",
         }
         return test_result, report_artifact
+
+    @staticmethod
+    def _app_invocation(inputs: dict[str, Any]) -> AppInvocation | None:
+        """The stack's own definition of "invokes the application" (#1126), resolved
+        through the scaffold registry from the cycle's build profile. ``None`` for an
+        unknown stack: the self-mocking detector then judges nothing and its row is
+        banked with an EMPTY inspected inventory (#986) — "did not look", never "clean".
+        """
+        from squadops.capabilities.scaffold import app_invocation_for, scaffold_stack_for
+
+        return app_invocation_for(scaffold_stack_for(inputs.get("resolved_config")))
 
     @staticmethod
     def _prompt_scoped_contents(
@@ -875,11 +887,14 @@ class QATestHandler(_CycleTaskHandler):
         # #915 on the retest path for the same reason: a repair told to make the suite
         # pass can satisfy that instruction by mocking the subject, and mocking is the
         # cheapest way to make any assertion true.
-        mock_offenders = detect_self_mocking_tests(artifacts)
+        invocation = self._app_invocation(inputs)
+        mock_offenders = detect_self_mocking_tests(artifacts, invocation)
         mock_paths = [path for path, _ in mock_offenders]
         checks.append(
             _authenticity_row(
-                CHECK_NO_SELF_MOCKING_TESTS, mock_paths, inspected_js_test_paths(artifacts)
+                CHECK_NO_SELF_MOCKING_TESTS,
+                mock_paths,
+                inspected_js_test_paths(artifacts) if invocation else [],
             )
         )
         if mock_offenders:
@@ -1384,11 +1399,14 @@ class QATestHandler(_CycleTaskHandler):
             # asserts what it told its own mock to return and therefore PASSES. Fills
             # cannot do this (the frozen spine invokes the handler and enforcement
             # rejects edits to it); additive files carried the rule only as prose.
-            mock_offenders = detect_self_mocking_tests(artifacts)
+            invocation = self._app_invocation(inputs)
+            mock_offenders = detect_self_mocking_tests(artifacts, invocation)
             mock_paths = [path for path, _ in mock_offenders]
             validation.checks.append(
                 _authenticity_row(
-                    CHECK_NO_SELF_MOCKING_TESTS, mock_paths, inspected_js_test_paths(artifacts)
+                    CHECK_NO_SELF_MOCKING_TESTS,
+                    mock_paths,
+                    inspected_js_test_paths(artifacts) if invocation else [],
                 )
             )
             if mock_offenders:

--- a/src/squadops/capabilities/handlers/stub_detection.py
+++ b/src/squadops/capabilities/handlers/stub_detection.py
@@ -34,6 +34,8 @@ from __future__ import annotations
 
 import re
 
+from squadops.capabilities.app_invocation import NETWORK_SEAM_FETCH_STUB, AppInvocation
+
 # Web-app constructors whose presence alongside an import guard signals that the
 # test rebuilt the app inline as a fallback (the stub).
 _APP_CONSTRUCTORS: tuple[str, ...] = (
@@ -118,33 +120,16 @@ _JS_TEST_SUFFIXES: tuple[str, ...] = (
     ".spec.jsx",
 )
 
-#: Replacing the network seam. Under the in-process execution model (#877) a suite reaches
-#: the app by importing its route handler, so there is no fetch for a correct suite to
-#: stub — the presence of a stub means the suite is talking to something it built.
-_NETWORK_SEAM_MOCK = re.compile(
-    r"""(?x)
-      global(?:This)?\s*\.\s*fetch\s*=                          # global.fetch = ...
-    | (?:vi|jest)\s*\.\s*stubGlobal\s*\(\s*['"`]fetch['"`]      # vi.stubGlobal('fetch', ...)
-    | (?:vi|jest)\s*\.\s*spyOn\s*\(\s*global(?:This)?\s*,\s*['"`]fetch['"`]
-    """
-)
+#: The stack's declaration of how a suite invokes the application, and the shared
+#: fetch-stub half of the network-seam rule (#1126). Defined in the leaf module
+#: ``capabilities.app_invocation`` so the stack modules can declare one without importing
+#: the handler package; re-exported here because this is the detector that applies it.
+__all__ = ["AppInvocation", "NETWORK_SEAM_FETCH_STUB"]
 
-#: Mocking the subject itself. Unconditional: there is no reading under which replacing
-#: the route module under test and then asserting on it verifies the route module.
-_ROUTE_MODULE_MOCK = re.compile(r"""(?:vi|jest)\s*\.\s*mock\s*\(\s*['"`][^'"`]*app/api/""")
-
-#: A real import of an application route module — the in-process model's entry point.
-#: Required as a *statement* rather than as any occurrence of the path, so that a
-#: ``vi.mock('@/app/api/...')`` string cannot satisfy it.
-_APP_ROUTE_IMPORT = re.compile(
-    r"""^\s*(?:import\b[^\n]*?from\s*|.*\brequire\s*\(\s*)['"`][^'"`]*app/api/""",
-    re.MULTILINE,
-)
-
-MOCKS_THE_SUBJECT = "mocks the route module under test and asserts on the mock"
+MOCKS_THE_SUBJECT = "mocks the module under test and asserts on the mock"
 MOCKS_THE_NETWORK = (
-    "replaces the fetch seam and imports no route module, so the application is "
-    "never invoked — the suite asserts what it told its own mock to return"
+    "replaces the seam it would reach the application through and never invokes it — "
+    "the suite asserts what it told its own mock to return"
 )
 
 
@@ -154,30 +139,37 @@ def _is_js_test_file(path: str) -> bool:
     return name.endswith(_JS_TEST_SUFFIXES)
 
 
-def detect_self_mocking_tests(files: list[dict]) -> list[tuple[str, str]]:
+def detect_self_mocking_tests(
+    files: list[dict], invocation: AppInvocation | None
+) -> list[tuple[str, str]]:
     """Return ``(path, reason)`` for generated suites that assert against their own mock.
 
     Deliberately two-clause and conservative, mirroring the stub-fallback heuristic. A
-    suite that mocks an *outbound* call while still importing and invoking the real route
-    handler is legitimate and is not flagged — mocking is not the defect, mocking
-    **instead of** invoking is. The discriminator is whether an application route module
-    is imported at all.
+    suite that mocks an *outbound* seam while still invoking the real application is
+    legitimate and is not flagged — mocking is not the defect, mocking **instead of**
+    invoking is. What counts as invoking the application is ``invocation``, the stack's
+    own declaration (#1126); with none — an unregistered stack — the detector cannot
+    judge and flags nothing, which the caller records as a skipped check rather than a
+    clean one.
 
     Args:
         files: extracted-file or artifact dicts (each with a name/filename/path
             and ``content``).
+        invocation: the stack's :class:`AppInvocation`, or ``None`` when unknown.
 
     Returns:
         Sorted ``(path, reason)`` pairs; empty when none are found.
     """
+    if invocation is None:
+        return []
     offenders: list[tuple[str, str]] = []
     for f in files:
         path, content = _file_field(f)
         if not path or not _is_js_test_file(path):
             continue
-        if _ROUTE_MODULE_MOCK.search(content):
+        if invocation.mocks_subject(content):
             offenders.append((path, MOCKS_THE_SUBJECT))
-        elif _NETWORK_SEAM_MOCK.search(content) and not _APP_ROUTE_IMPORT.search(content):
+        elif invocation.mocks_network(content) and not invocation.invokes(content):
             offenders.append((path, MOCKS_THE_NETWORK))
     return sorted(offenders)
 

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -37,6 +37,8 @@ import yaml
 # #822: stack #2's expander lives in its own module — a second one inline would push this
 # file past 2000 lines and interleave two stacks' source templates. No cycle: it annotates
 # against ``InterfaceManifest`` under ``TYPE_CHECKING`` and imports nothing here at runtime.
+from squadops.capabilities.app_invocation import NETWORK_SEAM_FETCH_STUB, AppInvocation
+from squadops.capabilities.stack_nextjs_ts import APP_INVOCATION as _APP_INVOCATION_NEXTJS_TS
 from squadops.capabilities.stack_nextjs_ts import STACK_NAME as _NEXTJS_TS_NAME
 from squadops.capabilities.stack_nextjs_ts import expand_nextjs_ts as _expand_nextjs_ts
 from squadops.capabilities.stack_nextjs_ts import (
@@ -1949,6 +1951,11 @@ class ScaffoldStack:
     #: that every gate accepted. Visible-and-unverified has a safe default; silently-wrong
     #: does not.
     criteria_pack: str = ""
+    #: #1126: how a suite on this stack invokes the application, for the self-mocking
+    #: detector — the import that proves the app is invoked, the mock that replaces the
+    #: subject, the mock that replaces the network seam. ``None`` means the detector cannot
+    #: judge this stack and its check is recorded as skipped, never as clean.
+    app_invocation: AppInvocation | None = None
     #: #822: the probe-boot profile ``handlers.probe_runner`` uses to stand this stack's app
     #: up for behavioral probes — the launcher and entry point (``uvicorn backend.main:app``
     #: vs ``node dist/server.js``) and the readiness path. A *name*, like ``criteria_pack``,
@@ -2023,6 +2030,21 @@ _STACKS: dict[str, ScaffoldStack] = {
         criteria_pack="fullstack_fastapi_react",
         error_seam=ERROR_SEAM_FASTAPI,
         probe_profile="fastapi_uvicorn",
+        # #1126: a React SPA reaches the app by rendering a real component or ``App``; the
+        # network is a seam UNDER it, so a global ``fetch`` stub or a mock of the app's own
+        # ``api.js`` client is legitimate when a component is rendered and self-mocking when
+        # nothing is. Mocking a view or ``App`` module itself is mocking the subject.
+        app_invocation=AppInvocation(
+            invocation_import=(
+                r"""^\s*(?:import\b[^\n]*?from\s*|.*\brequire\s*\(\s*)['"`][^'"`]*"""
+                r"""(?:/App|/views/[A-Za-z0-9_]+)(?:\.[jt]sx?)?['"`]"""
+            ),
+            subject_mock=r"""(?:vi|jest)\s*\.\s*mock\s*\(\s*['"`][^'"`]*(?:/App|/views/)""",
+            network_seam_mock=(
+                NETWORK_SEAM_FETCH_STUB
+                + r"""    | (?:vi|jest)\s*\.\s*mock\s*\(\s*['"`][^'"`]*/api(?:\.[jt]sx?)?['"`]"""
+            ),
+        ),
         # A declared success_status lands in the frozen route decorator
         # (``status_code=``, the pf-39 fix) — structural, fill-proof.
         skeleton_pins_success_status=True,
@@ -2049,6 +2071,7 @@ _STACKS: dict[str, ScaffoldStack] = {
         criteria_pack=_NEXTJS_TS_NAME,
         error_seam=ERROR_SEAM_NEXTJS_TS,
         probe_profile="nextjs_next_start",
+        app_invocation=_APP_INVOCATION_NEXTJS_TS,
         dev_capability=_NEXTJS_TS_NAME,
         # SIP-0104: the first (and so far only) stack with a deterministic test scaffold.
         # Stack #1 deliberately does not declare one — opt-in is explicit, never inherited.
@@ -2113,6 +2136,18 @@ def check_stack_for(stack: str) -> str | None:
     """
     known = _STACKS.get(stack)
     return (known.check_stack or None) if known else None
+
+
+def app_invocation_for(stack: str) -> AppInvocation | None:
+    """How a suite on ``stack`` invokes the application, or ``None`` (#1126).
+
+    Companion to :func:`check_stack_for`, for the same reason: "what does this stack count
+    as invoking the app" has one answer, and it is the stack's. ``None`` for an unknown or
+    undeclaring stack — the self-mocking detector then judges nothing and its row is
+    recorded as skipped, never as clean.
+    """
+    known = _STACKS.get(stack)
+    return known.app_invocation if known else None
 
 
 def criteria_pack_for(stack: str) -> str:

--- a/src/squadops/capabilities/stack_nextjs_ts.py
+++ b/src/squadops/capabilities/stack_nextjs_ts.py
@@ -35,12 +35,24 @@ import re
 from collections.abc import Collection
 from typing import TYPE_CHECKING, Any
 
+from squadops.capabilities.app_invocation import AppInvocation
 from squadops.capabilities.success_status import success_status_for
 
 if TYPE_CHECKING:  # pragma: no cover - annotations only, avoids a scaffold import cycle
     from squadops.capabilities.scaffold import InterfaceManifest
 
 STACK_NAME = "nextjs_ts"
+
+#: #1126: how a suite on this stack invokes the application. Under the in-process model
+#: (#877) a suite reaches the app by importing its ``app/api/`` route handler — required as
+#: an import *statement*, so a ``vi.mock('@/app/api/...')`` string cannot satisfy it — so
+#: there is no ``fetch`` for a correct suite to stub, and mocking the route module under
+#: test is unconditionally self-mocking. These three patterns used to live in the shared
+#: detector as if they were every stack's; they are this stack's.
+APP_INVOCATION = AppInvocation(
+    invocation_import=r"""^\s*(?:import\b[^\n]*?from\s*|.*\brequire\s*\(\s*)['"`][^'"`]*app/api/""",
+    subject_mock=r"""(?:vi|jest)\s*\.\s*mock\s*\(\s*['"`][^'"`]*app/api/""",
+)
 
 _TS_TYPES = {
     "str": "string",

--- a/tests/unit/capabilities/test_build_handlers.py
+++ b/tests/unit/capabilities/test_build_handlers.py
@@ -1447,14 +1447,43 @@ class TestQARetestExecuteOnly:
                 }
             ],
         }
+        from squadops.capabilities.stack_nextjs_ts import APP_INVOCATION
+
         handler = QATestHandler()
-        result = await handler.handle(mock_context, clean)
+        # #1126: the detector judges through the STACK's declaration of "invokes the
+        # app"; this suite is Next.js-shaped, so hand it that stack's definition.
+        with patch.object(QATestHandler, "_app_invocation", return_value=APP_INVOCATION):
+            result = await handler.handle(mock_context, clean)
 
         assert result.success is True
         rows = result.outputs["validation_result"]["checks"]
         mock_row = next(r for r in rows if r["check"] == "no_self_mocking_tests")
         assert mock_row["passed"] is True
         assert mock_row["inspected"] == ["__tests__/runs.test.ts"]
+        assert "offenders" not in mock_row
+
+    @patch(_RUN_TESTS_PATH, return_value=_MOCK_TEST_RESULT_PASSED)
+    async def test_unknown_stack_banks_the_self_mocking_row_as_not_looked(
+        self, _mock_run, mock_context, qa_inputs
+    ):
+        """#1126: with no registered stack the detector has no definition of "invokes
+        the app" and judges nothing — the row is banked with an EMPTY inventory (#986's
+        "did not look"), never as a clean pass over files it could not judge."""
+        unknown = {
+            **{k: v for k, v in qa_inputs.items() if k != "resolved_config"},
+            "retest_files": [
+                {
+                    "filename": "__tests__/runs.test.ts",
+                    "content": "global.fetch = vi.fn()\nit('x', () => {})\n",
+                }
+            ],
+        }
+        result = await QATestHandler().handle(mock_context, unknown)
+
+        rows = result.outputs["validation_result"]["checks"]
+        mock_row = next(r for r in rows if r["check"] == "no_self_mocking_tests")
+        assert mock_row["passed"] is True
+        assert mock_row["inspected"] == []
         assert "offenders" not in mock_row
 
     @patch(_RUN_TESTS_PATH, return_value=_MOCK_TEST_RESULT_PASSED)

--- a/tests/unit/capabilities/test_stub_detection.py
+++ b/tests/unit/capabilities/test_stub_detection.py
@@ -16,8 +16,15 @@ from squadops.capabilities.handlers.stub_detection import (
     detect_self_mocking_tests,
     detect_stub_fallback_tests,
 )
+from squadops.capabilities.scaffold import app_invocation_for
+from squadops.capabilities.stack_nextjs_ts import APP_INVOCATION as NEXTJS_APP_INVOCATION
 
 pytestmark = [pytest.mark.domain_capabilities]
+
+
+def _detect_nextjs(files):
+    """The Next.js cases, through that stack's own declaration (#1126)."""
+    return detect_self_mocking_tests(files, NEXTJS_APP_INVOCATION)
 
 
 _STUB_FALLBACK = """\
@@ -173,7 +180,7 @@ class TestSelfMockingSuites:
     verification."""
 
     def test_roll_threes_real_suite_is_flagged(self):
-        offenders = detect_self_mocking_tests(
+        offenders = _detect_nextjs(
             [{"name": "__tests__/api/runs.test.ts", "content": _SELF_MOCKING}]
         )
         assert offenders == [("__tests__/api/runs.test.ts", MOCKS_THE_NETWORK)]
@@ -183,9 +190,7 @@ class TestSelfMockingSuites:
         model answer — imports the route module, invokes the handler, asserts on the
         real response — and a detector that flags it would reject correct work."""
         assert (
-            detect_self_mocking_tests(
-                [{"name": "__tests__/participants.test.ts", "content": _REAL_ADDITIVE}]
-            )
+            _detect_nextjs([{"name": "__tests__/participants.test.ts", "content": _REAL_ADDITIVE}])
             == []
         )
 
@@ -194,9 +199,7 @@ class TestSelfMockingSuites:
         stubs an outbound dependency and still drives the real handler is exactly what
         a caller should be allowed to write."""
         content = _REAL_ADDITIVE + "\nglobal.fetch = vi.fn()  // stub the upstream weather API\n"
-        assert (
-            detect_self_mocking_tests([{"name": "__tests__/x.test.ts", "content": content}]) == []
-        )
+        assert _detect_nextjs([{"name": "__tests__/x.test.ts", "content": content}]) == []
 
     def test_mocking_the_route_module_is_flagged_even_when_it_is_also_imported(self):
         """The hole the import-based discriminator would otherwise leave: mock the
@@ -208,7 +211,7 @@ class TestSelfMockingSuites:
             "vi.mock('@/app/api/runs/route')\n"
             "import * as route from '@/app/api/runs/route'\n"
         )
-        offenders = detect_self_mocking_tests([{"name": "__tests__/y.test.ts", "content": content}])
+        offenders = _detect_nextjs([{"name": "__tests__/y.test.ts", "content": content}])
         assert offenders == [("__tests__/y.test.ts", MOCKS_THE_SUBJECT)]
 
     @pytest.mark.parametrize(
@@ -222,13 +225,13 @@ class TestSelfMockingSuites:
     )
     def test_each_way_of_replacing_the_seam_is_recognised(self, stub_line):
         content = f"import {{ vi }} from 'vitest'\n{stub_line}\nawait fetch('/api/runs')\n"
-        offenders = detect_self_mocking_tests([{"name": "__tests__/z.test.ts", "content": content}])
+        offenders = _detect_nextjs([{"name": "__tests__/z.test.ts", "content": content}])
         assert offenders == [("__tests__/z.test.ts", MOCKS_THE_NETWORK)]
 
     def test_a_non_test_file_is_ignored(self):
         """The delivered client seam legitimately calls fetch; it is not a test."""
         content = "export async function api(path: string) { return fetch(path) }\n"
-        assert detect_self_mocking_tests([{"name": "lib/api.ts", "content": content}]) == []
+        assert _detect_nextjs([{"name": "lib/api.ts", "content": content}]) == []
 
     def test_the_two_detectors_do_not_reach_into_each_others_languages(self):
         """One module, two vocabularies. A Python stub-fallback is not a self-mocking
@@ -239,7 +242,7 @@ class TestSelfMockingSuites:
             {"name": "__tests__/runs.test.ts", "content": _SELF_MOCKING},
         ]
         assert detect_stub_fallback_tests(files) == ["test_api.py"]
-        assert [path for path, _ in detect_self_mocking_tests(files)] == ["__tests__/runs.test.ts"]
+        assert [path for path, _ in _detect_nextjs(files)] == ["__tests__/runs.test.ts"]
 
     def test_multiple_offenders_are_sorted(self):
         files = [
@@ -247,7 +250,7 @@ class TestSelfMockingSuites:
             {"name": "__tests__/a.spec.tsx", "content": _SELF_MOCKING},
             {"name": "__tests__/ok.test.ts", "content": _REAL_ADDITIVE},
         ]
-        assert [path for path, _ in detect_self_mocking_tests(files)] == [
+        assert [path for path, _ in _detect_nextjs(files)] == [
             "__tests__/a.spec.tsx",
             "__tests__/b.test.ts",
         ]
@@ -262,4 +265,96 @@ class TestSelfMockingSuites:
         ],
     )
     def test_empty_or_nameless_inputs_do_not_crash(self, files):
-        assert detect_self_mocking_tests(files) == []
+        assert _detect_nextjs(files) == []
+
+
+class TestSelfMockingOnFastapiReact:
+    """#1126: the rule is stack-neutral, the definition of "invokes the app" is not. On a
+    React SPA a suite reaches the app by rendering a real component or ``App``; the network
+    is a seam UNDER it. The 03:26Z suite of 1.6.5 FastAPI+React roll 1
+    (`cyc_b9296c255dfc`, `art_477b87f85956`) rendered the real ``App`` with ``fetch``
+    stubbed, passed 3/3, and was failed by the Next.js definition; both accepted shakeouts
+    got past it with ``vi.mock('../api.js')``, the more self-mocking shape."""
+
+    REACT = app_invocation_for("fullstack_fastapi_react")
+
+    # The discarded green, trimmed to its imports and seam handling.
+    ROLL_1_SUITE = """\
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import App from '../App.jsx'
+
+describe('runs', () => {
+  let fetchMock
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+  afterEach(() => { cleanup() })
+  it('create run then see it in the list', async () => {
+    render(<MemoryRouter><App /></MemoryRouter>)
+  })
+})
+"""
+
+    def test_the_discarded_green_suite_is_legitimate(self):
+        files = [{"name": "frontend/src/__tests__/runs.test.jsx", "content": self.ROLL_1_SUITE}]
+        assert detect_self_mocking_tests(files, self.REACT) == []
+
+    def test_a_view_import_counts_as_invoking_the_app(self):
+        content = (
+            "import RunsListView from '../views/RunsListView.jsx'\n"
+            "vi.stubGlobal('fetch', vi.fn())\n"
+        )
+        files = [{"name": "frontend/src/__tests__/list.test.jsx", "content": content}]
+        assert detect_self_mocking_tests(files, self.REACT) == []
+
+    @pytest.mark.parametrize(
+        "seam",
+        [
+            "vi.stubGlobal('fetch', vi.fn())",
+            "global.fetch = vi.fn()",
+            "vi.mock('../api.js', () => ({ apiFetch: vi.fn() }))",
+        ],
+        ids=["fetch-stub", "global-fetch", "api-module-mock"],
+    )
+    def test_replacing_the_seam_without_rendering_anything_is_self_mocking(self, seam):
+        content = (
+            f"import {{ describe, it, expect, vi }} from 'vitest'\n{seam}\nit('x', () => {{}})\n"
+        )
+        files = [{"name": "frontend/src/__tests__/runs.test.jsx", "content": content}]
+        assert detect_self_mocking_tests(files, self.REACT) == [
+            ("frontend/src/__tests__/runs.test.jsx", MOCKS_THE_NETWORK)
+        ]
+
+    def test_mocking_the_api_client_while_rendering_a_view_is_legitimate(self):
+        """The shakeouts' shape: an outbound seam mocked, the real component rendered."""
+        content = (
+            "import RunDetailView from '../views/RunDetailView.jsx'\n"
+            "vi.mock('../api.js', () => ({ apiFetch: vi.fn() }))\n"
+        )
+        files = [{"name": "frontend/src/__tests__/detail.test.jsx", "content": content}]
+        assert detect_self_mocking_tests(files, self.REACT) == []
+
+    @pytest.mark.parametrize(
+        "mock", ["vi.mock('../views/RunsListView.jsx')", "vi.mock('../App.jsx', () => ({}))"]
+    )
+    def test_mocking_a_view_or_app_is_mocking_the_subject_even_when_imported(self, mock):
+        content = f"import App from '../App.jsx'\n{mock}\nvi.stubGlobal('fetch', vi.fn())\n"
+        files = [{"name": "frontend/src/__tests__/app.test.jsx", "content": content}]
+        assert detect_self_mocking_tests(files, self.REACT) == [
+            ("frontend/src/__tests__/app.test.jsx", MOCKS_THE_SUBJECT)
+        ]
+
+    def test_the_nextjs_definition_would_still_reject_the_react_green(self):
+        """The bug, kept as a test: the two stacks' definitions must differ here."""
+        files = [{"name": "frontend/src/__tests__/runs.test.jsx", "content": self.ROLL_1_SUITE}]
+        assert detect_self_mocking_tests(files, NEXTJS_APP_INVOCATION) == [
+            ("frontend/src/__tests__/runs.test.jsx", MOCKS_THE_NETWORK)
+        ]
+
+    def test_an_unknown_stack_judges_nothing(self):
+        files = [{"name": "x.test.js", "content": "global.fetch = vi.fn()\n"}]
+        assert detect_self_mocking_tests(files, None) == []
+        assert app_invocation_for("cobol_cics") is None


### PR DESCRIPTION
## Summary

**1.6.6 item C (#1126).** `detect_self_mocking_tests` defined "invokes the application" as *an import of an `app/api/` route module* — the Next.js in-process model (#877) — inside the shared `handlers/stub_detection.py`, with no stack parameter. On the 1.6.5 FastAPI+React set it failed a **green** suite that rendered the real `App` with `fetch` stubbed (roll 1, `art_477b87f85956`, 3/3 passed at 03:26Z → `handler_failed` two seconds later → round 2 → rejected) while passing the `vi.mock('../api.js')` shape both accepted shakeouts used. This is the bleed the owner asked about on 08-27; the fix goes through the seam that already exists rather than widening the regex.

**The rule stays stack-neutral; the definition becomes the stack's.** `AppInvocation` (`src/squadops/capabilities/app_invocation.py`, a leaf module like `success_status` so stack modules and the handler package need not import each other) carries three regex sources: the import that proves the app is invoked, the mock that replaces the subject (unconditional), the mock that replaces the network seam (flagged only when nothing invokes the app). Each `ScaffoldStack` declares one — Next.js in `stack_nextjs_ts.py` (its former patterns, verbatim), stack #1 inline beside its expander until #1131 moves it — and `app_invocation_for(stack)` sits beside `check_stack_for`. The detector takes the declaration and only applies it; both qa call sites resolve it from the cycle's build profile.

On FastAPI+React: importing `App` or a `views/` component invokes the app; a `fetch` stub **or** a mock of the app's own `api.js` under a rendered component is legitimate; mocking a view or `App` module is mocking the subject. (The issue body called the `api.js` mock "the self-mock"; on the evidence it is the *network seam* — the shakeouts mocked it while rendering real views, which is a legitimate component test. Recorded in the tests.)

**An unregistered stack is judged not at all**: the detector returns nothing and the qa handler banks the `no_self_mocking_tests` row with an **empty inspected inventory** (#986's "did not look"), never as a clean pass over files it could not judge.

## Tests

- `TestSelfMockingOnFastapiReact`: the discarded roll-1 suite passes under the React definition **and is still rejected under the Next.js one** (the bug kept as a test, so the two definitions can never collapse); a view import invokes; each seam replacement without a render is flagged; `api.js` mock + rendered view is legitimate; mocking a view/`App` is the subject; unknown stack judges nothing.
- Existing Next.js cases run through that stack's declaration unchanged.
- Handler: the #986 clean-row test hands the handler the Next.js definition; a new sibling asserts the unknown-stack row carries `inspected: []`.
- `./scripts/dev/run_regression_tests.sh` — 8053 passed, 1 skipped, exit 0. Next.js reference scaffold pin and the stack-#1 contract reference are untouched.

## Closes

Closes #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tj9vAj9yumEzAmBLrZnrX
