### PR TITLE
fix(correction): a repair patch refused by patch verification is not a correction round (#1129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,17 @@ All notable changes to SquadOps are recorded here. Format loosely follows
   stub or `api.js` mock under it is legitimate; mocking a view or `App` module is mocking
   the subject. An unregistered stack is judged not at all and its row is banked with an
   empty inspected inventory, never as clean. The discarded roll-1 suite is the replay test.
+- **D — a refused repair patch is not a correction round** (#1129). When patch
+  verification refused a repair nothing was applied and no retest ran, but the failed task
+  re-ran against the unrepaired tree, its signature repeated by construction, and the
+  progress-aware terminal read that as "the repair did not help" — two FastAPI+React rolls
+  ended `plan_defect` after zero applied repairs, one of them holding the correct fix. A
+  refused round now clears chain adjacency the way an infra round does (the attempt cap
+  still bounds a repair that keeps being refused); the executor's refusal entry and the
+  runner's reading of it share one marker. `endpoint_defined` resolves `APIRouter(prefix=…)`
+  so a prefixed router serves the declared paths instead of failing a literal-path check,
+  and the repair brief (v6) says to keep the router construction, decorators and handler
+  names as they are — a rewrite is refused before it is tested.
 
 ## [1.6.5] — 2026-08-27
 

--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -50,6 +50,7 @@ from squadops.cycles.correction_signature import (
     classify_movement,
     failure_signature,
     render_signature,
+    repair_refused_in_round,
     should_terminate_plan_defect,
 )
 from squadops.cycles.failure_evidence import build_failure_evidence, compose_failure_trigger
@@ -1153,6 +1154,7 @@ class CorrectionRunner:
         cycle: Cycle,
         run_id: str,
         all_artifact_refs: list[str],
+        repair_rejections: list[str] | None = None,
     ) -> None:
         """#435 A4.3: terminate the chain as ``plan_defect`` on an exact
         adjacent repeat with structural candidates on both rounds.
@@ -1162,12 +1164,31 @@ class CorrectionRunner:
         termination the typed ``CorrectionTermination`` record is persisted as
         a ``correction_termination`` artifact and the chain aborts through the
         normal ``_ExecutionError`` path, so ``failure_reason`` (#427) names it.
+
+        #1129: a round whose repair patch verification REFUSED is not a round
+        this rule may count. Nothing was applied, no retest ran, and the failed
+        task re-ran against the unrepaired tree, so its signature repeats by
+        construction — "the repair did not help" and "the repair was never
+        applied" were indistinguishable here, and two 1.6.5 rolls ended
+        ``plan_defect`` after zero applied repairs. The previous round's
+        signature is treated as absent (the same clearing an infra round gets)
+        and this round becomes the chain's first-seen; the attempt cap still
+        bounds a repair that keeps being refused.
         """
         current_sig = failure_signature(failure_evidence)
         state = signature_state.get(envelope.task_id)
         if current_sig is None:
             signature_state.pop(envelope.task_id, None)
             return
+        if state and repair_refused_in_round(repair_rejections, int(state.get("round", -1))):
+            logger.info(
+                "plan_defect terminal: round %s's repair for task=%s was refused by patch "
+                "verification and never applied — its signature is not counted as a "
+                "repeat (#1129)",
+                state.get("round"),
+                envelope.task_id,
+            )
+            state = None
         prev_sig = state["signature"] if state else None
         prev_candidate = state["candidate"] if state else None
         candidate = delta.structural_plan_change_candidate
@@ -1229,6 +1250,7 @@ class CorrectionRunner:
             "signature": current_sig,
             "candidate": candidate,
             "first_seen_round": first_seen,
+            "round": correction_attempts,
             "delta_artifact_id": delta_artifact_id,
         }
 
@@ -1492,6 +1514,7 @@ class CorrectionRunner:
                 cycle=cycle,
                 run_id=run_id,
                 all_artifact_refs=all_artifact_refs,
+                repair_rejections=repair_rejections,
             )
 
         # 7. Handle patch path: dispatch repair tasks

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -52,6 +52,7 @@ from squadops.cycles.contract_derivation import (
     SEEDED_MANIFEST_FILENAME,
     is_interface_manifest,
 )
+from squadops.cycles.correction_signature import REPAIR_REFUSED_MARKER
 from squadops.cycles.frozen_check_validation import frozen_check_violations
 from squadops.cycles.manifest_authoring import (
     GATE_DECIDED_BY_NO_QUESTIONS,
@@ -3123,8 +3124,8 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             _record_repair_rejection(
                 repair_rejection_carry,
                 envelope.task_id,
-                f"correction attempt {correction_attempts}: repair REJECTED by patch "
-                f"verification ({verification.reason or 'failed checks'})"
+                f"correction attempt {correction_attempts}: {REPAIR_REFUSED_MARKER} "
+                f"({verification.reason or 'failed checks'})"
                 + (f" — {failed_detail}" if failed_detail else ""),
             )
             return "continue"

--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -276,8 +276,48 @@ def _skip_unsupported_stack() -> CheckOutcome:
 # ---------------------------------------------------------------------------
 
 
-def _decorator_route(decorator: ast.expr) -> tuple[str, str] | None:
-    """Extract (METHOD, path) from `@router.METHOD("/path")` or `@app.METHOD("/path")`."""
+def _router_prefixes(tree: ast.AST) -> dict[str, str]:
+    """``name -> prefix`` for every ``name = APIRouter(prefix="...")`` in the module.
+
+    The prefix is a routing fact, not a stylistic one: FastAPI serves ``prefix + path``.
+    Only a literal string prefix is read; anything computed leaves the router unprefixed,
+    which is the conservative reading (the check then looks for the literal path).
+    """
+    prefixes: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+            continue
+        func = node.value.func
+        ctor = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+        if ctor != "APIRouter":
+            continue
+        prefix = next(
+            (
+                kw.value.value
+                for kw in node.value.keywords
+                if kw.arg == "prefix"
+                and isinstance(kw.value, ast.Constant)
+                and isinstance(kw.value.value, str)
+            ),
+            None,
+        )
+        if prefix is None:
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                prefixes[target.id] = prefix
+    return prefixes
+
+
+def _decorator_route(
+    decorator: ast.expr, prefixes: dict[str, str] | None = None
+) -> tuple[str, str] | None:
+    """Extract (METHOD, path) from `@router.METHOD("/path")` or `@app.METHOD("/path")`.
+
+    With ``prefixes`` (#1129), a decorator on a prefixed router yields the path the app
+    actually serves — ``@runs.post("")`` on ``runs = APIRouter(prefix="/runs")`` is
+    ``POST /runs``.
+    """
     if not isinstance(decorator, ast.Call):
         return None
     if not isinstance(decorator.func, ast.Attribute):
@@ -289,7 +329,12 @@ def _decorator_route(decorator: ast.expr) -> tuple[str, str] | None:
         return None
     arg0 = decorator.args[0]
     if isinstance(arg0, ast.Constant) and isinstance(arg0.value, str):
-        return method.upper(), normalize_route(arg0.value)
+        receiver = decorator.func.value
+        prefix = (prefixes or {}).get(receiver.id, "") if isinstance(receiver, ast.Name) else ""
+        path = arg0.value
+        if prefix:
+            path = f"{prefix.rstrip('/')}/{path.lstrip('/')}"
+        return method.upper(), normalize_route(path or "/")
     return None
 
 
@@ -714,11 +759,15 @@ class EndpointDefinedCheck(BaseCheck):
         except SyntaxError:
             return CheckOutcome.error(reason="parse_failed")
 
+        # #1129: a router built with ``APIRouter(prefix="/runs")`` serves ``/runs`` from
+        # ``@router.post("")`` — the same endpoint the literal form declares. Reading only
+        # the decorator's literal refused a correct repair (1.6.5 FastAPI+React roll 6).
+        prefixes = _router_prefixes(tree)
         found: set[tuple[str, str]] = set()
         for node in ast.walk(tree):
             if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
                 for dec in node.decorator_list:
-                    parsed = _decorator_route(dec)
+                    parsed = _decorator_route(dec, prefixes)
                     if parsed is not None:
                         found.add(parsed)
 

--- a/src/squadops/cycles/correction_signature.py
+++ b/src/squadops/cycles/correction_signature.py
@@ -215,6 +215,28 @@ def should_terminate_plan_defect(
     )
 
 
+#: The executor's wording for a repair that patch verification REFUSED — never applied to
+#: the tree. One constant, two readers: the executor writes it into the run-lived
+#: rejection carry (#870), and the terminal below reads it to know that the previous
+#: round's failure signature was measured against an UNREPAIRED tree (#1129).
+REPAIR_REFUSED_MARKER = "repair REJECTED by patch verification"
+
+
+def repair_refused_in_round(repair_rejections: list[str] | None, round_no: int) -> bool:
+    """Whether round ``round_no``'s repair was refused by patch verification (#1129).
+
+    A refused patch is not a round the signature rule may count: no retest ran, the failed
+    task was re-dispatched against the unrepaired tree, and the failure signature repeated
+    *by construction*. Reading that repeat as "the repair did not help" is how 1.6.5
+    FastAPI+React rolls 5 and 6 ended as ``plan_defect`` after zero applied repairs — roll
+    6's refused patch carried the correct fix. The carry entry is the executor's own
+    ``"correction attempt N: <REPAIR_REFUSED_MARKER> …"`` line; a retest that ran and
+    FAILED is a different entry and stays informative.
+    """
+    prefix = f"correction attempt {round_no}: {REPAIR_REFUSED_MARKER}"
+    return any(str(entry).startswith(prefix) for entry in repair_rejections or [])
+
+
 def render_signature(signature: frozenset[tuple[str, str, str]]) -> tuple[str, ...]:
     """Stable human/artifact rendering: sorted ``check|subject|reason`` strings."""
     return tuple(sorted("|".join(element) for element in signature))

--- a/src/squadops/prompts/request_templates/request.cycle_repair_task.md
+++ b/src/squadops/prompts/request_templates/request.cycle_repair_task.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.cycle_repair_task
-version: "5"
+version: "6"
 required_variables:
   - prd
   - role
@@ -44,7 +44,11 @@ The repair MUST produce the following file(s) by name, using fenced code blocks 
 **This is a repair, not a rewrite.** Change the minimum necessary to fix the named failure.
 The file list above is the set you may emit — it is not a list of things that need changing.
 A file you are not fixing must be re-emitted byte-identical to what is already in the
-workspace.
+workspace. Keep the file's structure as it is: the router construction, every route
+decorator with its literal path, every function name and its signature. A repair that
+re-emits the file as a rewrite — a prefixed router, renamed handlers, dropped decorators —
+is refused by the acceptance checks before it is ever tested, even when the fix inside it
+is correct, and the round is lost.
 
 Unrelated changes are how a repair round is lost. Reshaping a response, rewording an error
 string, or refactoring validation while fixing something else introduces new failures that

--- a/tests/unit/cycles/test_acceptance_checks.py
+++ b/tests/unit/cycles/test_acceptance_checks.py
@@ -151,6 +151,43 @@ class TestEndpointDefined:
         )
         assert result.status == "skipped"
 
+    async def test_prefixed_router_serves_the_declared_paths(self, tmp_path: Path):
+        """#1129 (1.6.5 FastAPI+React roll 6): the repair's router was
+        ``APIRouter(prefix="/runs")`` with ``@router.post("")`` — the same ``POST /runs``
+        the literal form declares — and the check refused a correct fix on the
+        decorator's literal path."""
+        (tmp_path / "routes.py").write_text(
+            "from fastapi import APIRouter\n"
+            'router = APIRouter(prefix="/runs", tags=["runs"])\n'
+            "other = APIRouter(prefix=some_prefix)\n"
+            '@router.get("")\n'
+            "def get_runs():\n    return []\n"
+            '@router.post("", status_code=201)\n'
+            "def post_runs(body):\n    return {}\n"
+            '@router.get("/{run_id}")\n'
+            "def get_run(run_id: str):\n    return {}\n"
+            '@router.post("/{run_id}/join")\n'
+            "def join_run(run_id: str, body):\n    return {}\n"
+            '@other.get("/x")\n'
+            "def x():\n    return {}\n"
+        )
+        result = await get_check("endpoint_defined").evaluate(
+            {
+                "file": "routes.py",
+                "methods_paths": [
+                    "GET /runs",
+                    "POST /runs",
+                    "GET /runs/{run_id}",
+                    "POST /runs/{run_id}/join",
+                ],
+            },
+            tmp_path,
+            stack="fastapi",
+        )
+        assert result.status == "passed", result.actual
+        # a computed prefix is not read: that router's route stays literal
+        assert "GET /x" in result.actual["found"]
+
     async def test_missing_file_failed(self, fastapi_workspace):
         result = await get_check("endpoint_defined").evaluate(
             {"file": "does_not_exist.py", "methods_paths": ["GET /x"]},

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -3930,7 +3930,7 @@ class TestProgressAwareTermination:
 
         runner._dispatch_protocol_step = AsyncMock(side_effect=_step)
 
-    async def _run_round(self, runner, cycle, state, attempt: int):
+    async def _run_round(self, runner, cycle, state, attempt: int, **extra):
         return await runner.run_correction_protocol(
             run_id="run_001",
             cycle=cycle,
@@ -3943,6 +3943,7 @@ class TestProgressAwareTermination:
             completed_task_ids=[],
             plan_delta_refs=[],
             signature_state=state,
+            **extra,
         )
 
     async def test_adjacent_repeat_with_candidates_terminates(self, cycle):
@@ -3974,6 +3975,29 @@ class TestProgressAwareTermination:
             call.args[0].artifact_type for call in runner._artifact_vault.store.call_args_list
         ]
         assert "correction_termination" not in stored_types
+
+    async def test_a_refused_previous_round_is_not_a_repeat(self, cycle):
+        """#1129 (1.6.5 FastAPI+React rolls 5 and 6): round 0's patch was REFUSED by
+        patch verification — never applied, no retest — so round 1 measured the same
+        unrepaired tree and the signature repeated by construction. The rule read that
+        as "the repair did not help" and terminated after zero applied repairs; roll
+        6's refused patch carried the correct fix. A refused round clears adjacency
+        like an infra round; a round whose patch WAS applied still counts."""
+        from adapters.cycles.execution_errors import _ExecutionError
+        from squadops.cycles.correction_signature import REPAIR_REFUSED_MARKER
+
+        runner = self._runner()
+        self._wire_steps(runner, "tighten_acceptance")
+        state: dict = {}
+        refused_round_0 = [f"correction attempt 0: {REPAIR_REFUSED_MARKER} (unresolved_imports)"]
+
+        await self._run_round(runner, cycle, state, 0)
+        # round 1: same signature, but round 0 applied nothing → no termination
+        await self._run_round(runner, cycle, state, 1, repair_rejections=refused_round_0)
+        assert state["task-qa-4"]["first_seen_round"] == 1
+        # round 2: round 1's patch was applied (no refusal entry for it) → the repeat is real
+        with pytest.raises(_ExecutionError, match="plan_defect"):
+            await self._run_round(runner, cycle, state, 2, repair_rejections=refused_round_0)
 
     async def test_no_state_threaded_is_todays_behavior(self, cycle):
         # legacy callers without signature_state: byte-identical behavior

--- a/tests/unit/cycles/test_correction_signature.py
+++ b/tests/unit/cycles/test_correction_signature.py
@@ -16,9 +16,11 @@ from squadops.cycles.correction_signature import (
     MOVEMENT_PROGRESS,
     MOVEMENT_REPEAT,
     MOVEMENT_SHIFTED,
+    REPAIR_REFUSED_MARKER,
     classify_movement,
     failure_signature,
     render_signature,
+    repair_refused_in_round,
     should_terminate_plan_defect,
 )
 
@@ -352,3 +354,23 @@ class TestNoMachineReportDiscriminators:
         would disable A4 for every pre-#626 shape."""
         sig = failure_signature(_evidence([{"check": "frontend_build", "passed": False}]))
         assert render_signature(sig) == ("frontend_build||failed",)
+
+
+class TestRefusedRound:
+    """#1129: a round whose patch was refused by patch verification applied nothing; the
+    terminal must not read the next round's identical signature as "the repair did not
+    help" — 1.6.5 FastAPI+React rolls 5 and 6 ended plan_defect after zero applied repairs."""
+
+    def test_the_executors_own_entry_is_recognised(self):
+        carry = [f"correction attempt 0: {REPAIR_REFUSED_MARKER} (unresolved_imports) — main.py"]
+        assert repair_refused_in_round(carry, 0) is True
+        assert repair_refused_in_round(carry, 1) is False
+
+    def test_a_retest_that_ran_and_failed_is_not_a_refusal(self):
+        """The patch WAS applied and the suite still failed — that repeat is informative."""
+        carry = ["correction attempt 0: repaired suite retest FAILED — 3 validation errors"]
+        assert repair_refused_in_round(carry, 0) is False
+
+    @pytest.mark.parametrize("carry", [None, [], ["correction attempt 00: something else"]])
+    def test_absent_or_foreign_entries_never_match(self, carry):
+        assert repair_refused_in_round(carry, 0) is False


### PR DESCRIPTION
## Summary

**1.6.6 item D (#1129).** When `patch_verification` refused a repair, nothing was applied and no retest ran — but `qa.test` was re-dispatched against the unrepaired tree, its failure signature repeated *by construction*, and the progress-aware terminal (#435 A4.3) read the repeat as "the repair did not help" and ended the run `plan_defect`. 1.6.5 FastAPI+React rolls 5 (`cyc_0e7bc622169a`, refused: `unresolved_imports`) and 6 (`cyc_d43c644e52d0`, refused: `endpoint_defined` on a prefixed router — the patch carried the **correct** fix) both terminated after **zero applied repairs**, while rolls 2 and 4 landed the same one-line fix at round 0.

**Three parts, in the order of the issue's fix shape:**

1. **A refused round is not a round.** `correction_signature.py` gains `REPAIR_REFUSED_MARKER` — one wording, two readers: the executor writes it into the run-lived rejection carry (#870), the runner's `_check_progress_termination` reads it via `repair_refused_in_round` and treats a refused previous round as absent (the same clearing an infra round gets), re-anchoring first-seen. The signature state now records its round. A retest that **ran and failed** is a different carry entry and stays informative. The attempt cap still bounds a repair that keeps being refused.
2. **`endpoint_defined` resolves `APIRouter(prefix=…)`.** `_router_prefixes` reads literal-string prefixes; a decorator on a prefixed router yields the path the app serves (`@router.post("")` on a `/runs` router → `POST /runs`). Computed prefixes are not read — that router stays literal (conservative).
3. **The repair brief (v6)** adds one paragraph: keep the router construction, every decorator's literal path, every handler name and signature; a rewrite is refused before it is tested even when the fix inside is correct. Prompt content in the asset via `PromptService`, not a handler literal.

## Tests

- `TestRefusedRound`: the executor's own entry is recognised; a retest-FAILED entry is not a refusal; absent/foreign entries never match.
- `test_a_refused_previous_round_is_not_a_repeat` (runner): round 0 refused → round 1's identical signature does not terminate and re-anchors first-seen at 1 → round 2 (round 1's patch applied) terminates. The existing adjacent-repeat test is unchanged.
- `test_prefixed_router_serves_the_declared_paths`: roll 6's router shape passes; a computed prefix leaves that router literal.
- `./scripts/dev/run_regression_tests.sh` — 8047 passed, 1 skipped, exit 0.

## Closes

Closes #1129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tj9vAj9yumEzAmBLrZnrX
