### PR TITLE
fix(scaffold): an endpoint's request body has one resolver; an entity-typed request gets a body model (#1128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,17 @@ All notable changes to SquadOps are recorded here. Format loosely follows
   so a prefixed router serves the declared paths instead of failing a literal-path check,
   and the repair brief (v6) says to keep the router construction, decorators and handler
   names as they are — a rewrite is refused before it is tested.
+- **E — an endpoint's request body has one resolver** (#1128). Manifest validation accepts
+  a `request:` that names a declared shape *or an entity*; the contract generator resolved
+  probe bodies only through `request_shapes`, so an entity-typed request shipped `json: {}`
+  expecting 201 then 409 from a route whose payload class required `name` — unsatisfiable by
+  construction, and the loop rightly called it `plan_defect`. `InterfaceManifest.request_body_fields`
+  now answers for both (a shape's `required`; an entity's required, non-generated,
+  undefaulted fields) and every probe-body site reads it. The route emitter no longer takes
+  the entity class itself as the payload — its generated `id` is required, so it could never
+  accept that body — but a synthesized `{Entity}Body` model shaped by the same resolver,
+  with `NonBlankStr` required fields so the blank-input probe applies as it does to a
+  declared shape. Pinned reference output (declared shapes throughout) is byte-identical.
 
 ## [1.6.5] — 2026-08-27
 

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -256,6 +256,60 @@ class InterfaceManifest:
     #: author. Excluded from ``_canonical`` for the same reason ``decisions`` is.
     provenance: Provenance | None = None
 
+    def request_body_fields(self, request: str | None) -> tuple[str, ...]:
+        """The fields a body for ``request`` must carry — the ONE answer (#1128).
+
+        ``request`` is an endpoint's ``request:`` and validation accepts either a declared
+        request shape or an entity (see ``usability_errors``). The contract generator used
+        to resolve bodies only through ``request_shapes``, so an entity-typed request got
+        ``json: {}`` — a probe expecting 201 then 409 from a body the seeded route (which
+        takes the entity as its payload class) must 422. Unsatisfiable by construction;
+        1.6.5 FastAPI+React roll 3 was rejected on it while the loop correctly said
+        ``plan_defect``. A shape answers with its ``required``; an entity with the fields a
+        body MUST carry — required, not generated, no declared default; anything else
+        with nothing.
+        """
+        if not request:
+            return ()
+        for shape in self.api.request_shapes:
+            if shape.name == request:
+                return tuple(shape.required)
+        for entity in self.entities:
+            if entity.name == request:
+                return tuple(
+                    f.name
+                    for f in entity.fields
+                    if f.required and not f.generated and not f.has_default
+                )
+        return ()
+
+    def request_model_name(self, request: str | None) -> str | None:
+        """The Python model the route takes as its payload for ``request`` (#1128).
+
+        A declared shape is its own model. An entity-typed request gets a synthesized
+        ``{Entity}Body`` — the entity's body fields per :meth:`request_body_fields` — never
+        the entity class itself: the frozen entity requires its generated ``id``, so as a
+        payload class it could not accept the body the contract sends.
+        """
+        if not request:
+            return None
+        if any(shape.name == request for shape in self.api.request_shapes):
+            return request
+        if any(entity.name == request for entity in self.entities):
+            return f"{request}Body"
+        return None
+
+    def entity_typed_requests(self) -> tuple[str, ...]:
+        """Entities used directly as an endpoint's ``request:``, in first-use order."""
+        shape_names = {shape.name for shape in self.api.request_shapes}
+        entity_names = {entity.name for entity in self.entities}
+        seen: list[str] = []
+        for ep in self.api.endpoints:
+            if ep.request and ep.request in entity_names and ep.request not in shape_names:
+                if ep.request not in seen:
+                    seen.append(ep.request)
+        return tuple(seen)
+
     @classmethod
     def from_yaml(cls, content: str) -> InterfaceManifest:
         data = yaml.safe_load(content)
@@ -1357,7 +1411,33 @@ def _model_source(manifest: InterfaceManifest) -> str:
         for name in shape.optional:
             lines.append(f"    {name}: str | None = None")
         lines.append("")
+
+    lines.extend(_entity_body_model_lines(manifest))
     return "\n".join(lines)
+
+
+def _entity_body_model_lines(manifest: InterfaceManifest) -> list[str]:
+    """#1128: an entity used as an endpoint's ``request:`` gets a request model of its own.
+
+    Shaped by the same resolver the contract's probe bodies use — required, non-generated,
+    undefaulted fields as ``NonBlankStr`` (so the blank-input probe applies as it does to a
+    declared shape), every other non-generated field optional. The entity class itself
+    requires its generated ``id`` and could never accept the body the contract sends.
+    """
+    lines: list[str] = []
+    for entity_name in manifest.entity_typed_requests():
+        entity = next(e for e in manifest.entities if e.name == entity_name)
+        required = manifest.request_body_fields(entity_name)
+        optional = [f.name for f in entity.fields if not f.generated and f.name not in required]
+        lines.append(f"class {manifest.request_model_name(entity_name)}(BaseModel):")
+        if not required and not optional:
+            lines.append("    pass")
+        for name in required:
+            lines.append(f"    {name}: NonBlankStr")
+        for name in optional:
+            lines.append(f"    {name}: str | None = None")
+        lines.append("")
+    return lines
 
 
 def _route_func_name(ep: Endpoint) -> str:
@@ -1372,8 +1452,9 @@ def _routes_source(manifest: InterfaceManifest) -> str:
     }
     referenced: set[str] = set()
     for ep in manifest.api.endpoints:
-        if ep.request and ep.request in known_models:
-            referenced.add(ep.request)
+        request_model = manifest.request_model_name(ep.request)
+        if request_model:
+            referenced.add(request_model)
         if ep.response:
             base = _base_type_name(ep.response)
             if base in known_models:
@@ -1432,7 +1513,7 @@ def _routes_source(manifest: InterfaceManifest) -> str:
         path_args = [p[1:-1] for p in ep.path.split("/") if p.startswith("{") and p.endswith("}")]
         params = [f"{a}: str" for a in path_args]
         if ep.request:
-            params.append(f"payload: {ep.request}")
+            params.append(f"payload: {manifest.request_model_name(ep.request) or ep.request}")
         sig = ", ".join(params)
         decorator = f'@router.{ep.method.lower()}("{ep.path}"'
         if ep.response:

--- a/src/squadops/capabilities/scaffold_contract.py
+++ b/src/squadops/capabilities/scaffold_contract.py
@@ -447,10 +447,15 @@ def _probes(manifest: InterfaceManifest, pack: CriteriaPack) -> list[dict[str, A
     for ep in manifest.api.endpoints:
         if ep.method != "POST" or "{" in ep.path:
             continue
-        shape = shapes.get(ep.request or "")
+        # #1128: the body's fields come from the manifest's one resolver — a declared
+        # shape's required fields, or an entity-typed request's required non-generated
+        # ones — the same answer the route emitter's payload class encodes (an entity-typed
+        # request is emitted as ``{Entity}Body`` with ``NonBlankStr`` required fields, so
+        # the blank-input probe below applies to it exactly as to a declared shape).
+        body_fields = manifest.request_body_fields(ep.request)
         json_body = {
             field: _probe_sample_value(field, field_types.get(field, "string"))
-            for field in (shape.required if shape else ())
+            for field in manifest.request_body_fields(ep.request)
         }
         create_probe = {
             "id": f"vc-probe-{_slug(ep.path) or 'root'}",
@@ -488,7 +493,7 @@ def _probes(manifest: InterfaceManifest, pack: CriteriaPack) -> list[dict[str, A
         # every author happening to declare 422). A framework-fixed status
         # (pydantic's 422) stays fixed; a seam-owned stack derives from the
         # authored mapping, and an unmapped code omits the probe.
-        if shape and shape.required and manifest.api.error_contract:
+        if body_fields and manifest.api.error_contract:
             expected_rejection = (
                 pack.blank_rejection_status
                 if pack.blank_rejection_status is not None
@@ -502,7 +507,7 @@ def _probes(manifest: InterfaceManifest, pack: CriteriaPack) -> list[dict[str, A
                         "request": {
                             "method": ep.method,
                             "path": ep.path,
-                            "json": dict.fromkeys(shape.required, ""),
+                            "json": dict.fromkeys(body_fields, ""),
                         },
                         "expect": {
                             "status": expected_rejection,
@@ -534,10 +539,9 @@ def _probes(manifest: InterfaceManifest, pack: CriteriaPack) -> list[dict[str, A
             create_probe["capture"] = {param: "id"}
             create_slug = _slug(ep.path) or "root"
             for child in children:
-                child_shape = shapes.get(child.request or "")
                 child_body = {
                     field: _probe_sample_value(field, field_types.get(field, "string"))
-                    for field in (child_shape.required if child_shape else ())
+                    for field in manifest.request_body_fields(child.request)
                 }
                 action = child.path.rsplit("/", 1)[-1]
                 probes.append(
@@ -597,7 +601,7 @@ def _probes(manifest: InterfaceManifest, pack: CriteriaPack) -> list[dict[str, A
             for value in child_shape.declared_values(discriminator):
                 child_body = {
                     field: _probe_sample_value(field, field_types.get(field, "string"))
-                    for field in child_shape.required
+                    for field in manifest.request_body_fields(child.request)
                 }
                 child_body[discriminator] = value
                 probes.append(

--- a/tests/unit/capabilities/test_scaffold_contract.py
+++ b/tests/unit/capabilities/test_scaffold_contract.py
@@ -514,3 +514,83 @@ def test_the_runner_and_the_audit_reject_a_body_missing_a_derived_key():
     verdict = evaluate_expectations(create["expect"], 201, body)
     assert verdict == "response missing key(s): ['participants']"
     assert evaluate_expectations(create["expect"], 201, {**body, "participants": []}) is None
+
+
+class TestEntityTypedRequestBodies:
+    """#1128 (1.6.5 FastAPI+React roll 3, `cyc_184b3a1d194e`): the manifest wrote
+    ``POST /runs/{run_id}/participants  request: Participant`` — an entity, which
+    validation accepts — and the contract generator, resolving bodies only through
+    ``request_shapes``, emitted ``json: {}`` expecting 201 then 409 from a route whose
+    payload class requires ``name``. Roll 2 declared a shape and got ``{"name": "sample"}``;
+    that was the whole difference."""
+
+    @staticmethod
+    def _entity_typed_join() -> InterfaceManifest:
+        raw = _raw()
+        raw["api"]["request_shapes"].pop("ParticipantName")
+        for ep in raw["api"]["endpoints"]:
+            if ep.get("request") == "ParticipantName":
+                ep["request"] = "Participant"
+        return InterfaceManifest.from_dict(raw)
+
+    def test_the_resolver_answers_for_shapes_entities_and_nothing(self):
+        m = _manifest()
+        assert m.request_body_fields("RunEventCreate") == ("title", "datetime", "location")
+        assert m.request_body_fields("ParticipantName") == ("name",)
+        # an entity: what a body MUST carry — never the generated id, never a defaulted field
+        assert m.request_body_fields("RunEvent") == ("title", "datetime", "location")
+        assert m.request_body_fields("Participant") == ("name",)
+        assert m.request_body_fields("Nope") == ()
+        assert m.request_body_fields(None) == ()
+
+    def test_an_entity_typed_request_gets_the_entitys_required_fields(self):
+        contract = emit_contract_dict(self._entity_typed_join())
+        probes = {p["id"]: p for p in contract["behavioral"]["probes"]}
+        assert probes["vc-probe-runs-join"]["request"]["json"] == {"name": "sample"}
+        assert probes["vc-probe-runs-join-duplicate"]["request"]["json"] == {"name": "sample"}
+        assert probes["vc-probe-runs-leave"]["request"]["json"] == {"name": "sample"}
+
+    def test_the_seeded_route_accepts_exactly_the_probe_body(self):
+        """The two homes agree: the route emitter takes the entity as its payload class,
+        and the frozen model built from it accepts the body the contract now sends."""
+        import sys
+        import types
+
+        import pydantic
+
+        from squadops.capabilities.scaffold import expand
+
+        manifest = self._entity_typed_join()
+        files = {f["name"]: f["content"] for f in expand(manifest)}
+        # the route takes the synthesized body model, never the entity (whose generated
+        # `id` is required and would 422 the probe) — and imports it
+        routes = files["backend/routes.py"]
+        assert "payload: ParticipantBody" in routes
+        import_line = next(ln for ln in routes.splitlines() if ln.startswith("from .models import"))
+        assert "ParticipantBody" in import_line
+        probes = {p["id"]: p for p in emit_contract_dict(manifest)["behavioral"]["probes"]}
+        body = probes["vc-probe-runs-join"]["request"]["json"]
+        mod = types.ModuleType("frozen_models_1128")
+        sys.modules[mod.__name__] = mod
+        try:
+            exec(compile(files["backend/models.py"], "backend/models.py", "exec"), mod.__dict__)
+            assert mod.ParticipantBody(**body).name == "sample"
+            # #593 applies to the synthesized model too: blank input is rejected
+            with pytest.raises(pydantic.ValidationError):
+                mod.ParticipantBody(name="  ")
+            # the entity itself is untouched and still requires its generated id
+            with pytest.raises(pydantic.ValidationError):
+                mod.Participant(**body)
+        finally:
+            del sys.modules[mod.__name__]
+
+    def test_the_synthesized_model_is_shaped_by_the_resolver(self):
+        manifest = self._entity_typed_join()
+        models = {f["name"]: f["content"] for f in expand(manifest)}["backend/models.py"]
+        klass = models.split("class ParticipantBody(BaseModel):", 1)[1].split("\nclass ", 1)[0]
+        assert [ln.strip() for ln in klass.strip().splitlines()] == ["name: NonBlankStr"]
+        assert manifest.request_model_name("Participant") == "ParticipantBody"
+        assert manifest.request_model_name("ParticipantName") is None  # shape was removed
+        assert _manifest().request_model_name("ParticipantName") == "ParticipantName"
+        assert manifest.entity_typed_requests() == ("Participant",)
+        assert _manifest().entity_typed_requests() == ()


### PR DESCRIPTION
## Summary

**1.6.6 item E (#1128).** Manifest validation accepts an endpoint `request:` that names a declared shape **or an entity** (`scaffold.py`'s `usability_errors`); the contract generator resolved probe bodies only through `request_shapes` (`scaffold_contract.py:439`, `:537-541`), so 1.6.5 FastAPI+React roll 3's `POST /runs/{run_id}/participants  request: Participant` shipped `json: {}` expecting 201 then 409 from a route whose payload class required `name`. Unsatisfiable by construction; the loop correctly terminated `plan_defect` after one wasted dev repair.

**One resolver, on the manifest.** `InterfaceManifest.request_body_fields(request)`: a declared shape's `required`; an entity's required, non-generated, undefaulted fields (a body need not carry a generated `id` or a defaulted `participants`); nothing otherwise. Every probe-body site — the create probe, the path-param child actions, the discriminated children, and the blank-input probe — reads it.

**And the route emitter agrees by construction.** Writing the "two homes agree" test on the reference manifest surfaced the second half: `Participant` has a generated `id`, so the frozen entity model *requires* it — an entity used directly as the payload class (`payload: Participant`) can never accept the body the resolver sends. `request_model_name` now maps an entity-typed request to a synthesized `{Entity}Body` model, emitted by `_entity_body_model_lines` from the same resolver (`NonBlankStr` required fields, other non-generated fields optional), and the route takes and imports that. The blank-input probe therefore applies to entity-typed requests exactly as to declared shapes.

**Pins:** the reference manifest declares shapes throughout, so its contract (v11), the stack-#1 hash, the Next.js scaffold pin and the three goldens are byte-identical. Output changes only for manifests that write an entity-typed request — the shape that produced roll 3.

## Tests

- `TestEntityTypedRequestBodies`: the resolver's four answers (shape, entity minus generated/defaulted, unknown, none); roll 3's manifest shape yields `{"name": "sample"}` on join/join-duplicate/leave; the seeded route takes `ParticipantBody`, imports it, and the frozen model accepts exactly the probe body, rejects blank input (#593), while the entity itself still requires its `id`; the synthesized model is shaped by the resolver.
- `./scripts/dev/run_regression_tests.sh` — 8044 passed, 1 skipped, exit 0.

## Closes

Closes #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tj9vAj9yumEzAmBLrZnrX
