### PR TITLE
docs(plan): pre-register the 1.6.6 sets (4+4) + driver readouts R1/R2/R4/R5 + pinned set configs

### DIFF
--- a/docs/plans/1-6-6-verification-set-preregistration.md
+++ b/docs/plans/1-6-6-verification-set-preregistration.md
@@ -6,8 +6,9 @@ after both shakeouts, before the first counted launch. Merging it is the owner's
 not change what it pre-registers; the branch commit is the record.
 
 This is the 1.6.6 plan's §3 (`docs/plans/1-6-6-plan.md`, rev 1) with one change the owner
-made on 2026-08-27: **two counting sets of four, not one of six** — the FastAPI+React set that
-measures the pack, and a Next.js+TS regression arm that asks only whether anything moved.
+made on 2026-08-27: **six counting rolls on FastAPI+React and two on Next.js+TS** — six where
+every item of the pack came from, so the pack gets the most chances to be exercised, and a
+two-roll regression arm on the stack the pack is not supposed to touch.
 Everything not restated here is inherited **verbatim** from the 1.6.5 pre-registration
 (`docs/plans/1-6-5-verification-set-preregistration.md`) and, through it, 1.6.4 and 1.6.3:
 §5 (scoring), §5.1 (roll validity — void / reset / counted), §6 and §6.1 (the gate constant
@@ -28,7 +29,7 @@ written once; the driver refuses a counting roll when the deploy's image ids or 
 
 | Parameter | Value |
 |---|---|
-| N (rolls) | **4 counted** on FastAPI+React (the measurement, §3) and **4 counted** on Next.js+TS (the regression arm, §4). See §1.3 for what N=4 can and cannot say. |
+| N (rolls) | **6 counted** on FastAPI+React (the measurement, §3) and **2 counted** on Next.js+TS (the regression arm, §4). See §1.3 for what these sizes can and cannot say. |
 | Bar | **none** on either rate; each prediction is pass/fail on its own terms |
 | Project / PRD / squad / request profile | `group_run`, `full-38`, `validated-fullstack` — identical to 1.6.5 |
 | Overrides | FastAPI+React: none (`validated-fullstack`'s defaults are stack #1). Next.js+TS: `build_profile=nextjs_ts`, `dev_capability=nextjs_ts` |
@@ -40,18 +41,24 @@ written once; the driver refuses a counting roll when the deploy's image ids or 
 | Gate policy | 1.6.3 §6 constant, verbatim in each set config's `gate_notes`; `--as-agent`; both §6.1 paths satisfy zero-intervention and the decider is recorded per roll |
 | Audit instrument | `scripts/dev/audit_delivered_app.py` at the frozen deploy commit |
 | Driver | `verification_set_driver.py roll --set docs/plans/verification-sets/1-6-6-fastapi-react.yaml --roll N`, then `…/1-6-6-nextjs.yaml` — one roll per invocation |
-| Order | FastAPI+React rolls 1–4 first (the measurement), then Next.js+TS rolls 1–4 |
+| Order | FastAPI+React rolls 1–6 first (the measurement), then Next.js+TS rolls 1–2 |
 
-### 1.3 The honest limits of N=4
+### 1.3 The honest limits of 6 and 2
 
-Four rolls per arm is the owner's sizing, and this section says what it buys and what it
-does not. **It buys the mechanism questions**: every prediction in §3 and §4 is pass/fail per
-roll, and one falsification is a finding at N=1 — that is what stopped the previous sets early
-and it works at any N. **It does not buy a rate**: 4 of 4 is 95% CI [51%, 100%] (Wilson); 2 of
-4 is [9.5%, 90.5%]. Against the 1.6.5 FastAPI+React baseline of 2 of 6 ([9.7%, 70.0%]) no
-outcome of four rolls can claim a significant change, and this document does not. Against
-the Next.js 6 of 6, four greens say "nothing moved" and one red is one red — a finding to
-attribute, not a rate. The verdict counts are reported with their intervals and no bar.
+Six and two are the owner's sizing (2026-08-27, from a 4+4 first draft), and this section says
+what they buy and what they do not. **Six on FastAPI+React buys exercise, not a rate.** Every
+prediction in §3 is pass/fail per roll, and one falsification is a finding at N=1 — that is what
+stopped the previous sets early and it works at any N. But several items only fire when a roll
+gives them the chance — A needs a manifest that writes `default: null` (five of eight 1.6.5-era
+manifests did), D and F need a correction round at all — so more rolls means more of the pack
+actually observed, and each roll's record says which items it exercised. It does **not** buy
+a rate: 6 of 6 is 95% CI [61%, 100%] (Wilson), 3 of 6 is [19%, 81%]; against the 1.6.5
+baseline of 2 of 6 ([9.7%, 70.0%]) no outcome claims a significant change, and this document
+does not. **Two on Next.js+TS buys one thing**: nothing in the pack is supposed to reach that
+stack (A/B/E by construction, byte-identical on the pinned reference; C/D/F loop code its
+1.6.5 set never ran), so two greens on the same protocol as its 6 of 6 say "nothing moved",
+and one red is a finding to attribute at N=1 — the 1.6.5 F1 lesson in reverse. Neither count
+is a rate; both are reported with their intervals and no bar.
 
 ---
 
@@ -72,7 +79,7 @@ attribute, not a rate. The verdict counts are reported with their intervals and 
 
 ---
 
-## 3. FastAPI+React (`fullstack_fastapi_react`) — the measurement, four rolls
+## 3. FastAPI+React (`fullstack_fastapi_react`) — the measurement, six rolls
 
 The set the 1.6.6 pack was built for. Every prediction is one item of the pack, read only from
 the evidence named, and each has a 1.6.5 roll that falsified it before the fix:
@@ -88,7 +95,7 @@ the evidence named, and each has a 1.6.5 roll that falsified it before the fix:
 | **S0–S3, Q3** | carried from 1.6.5 §4 unchanged | as there | as there | held 6/6 |
 
 **Texture, no prediction attached:** the verdict rate against 2 of 6 (Wilson interval, no
-bar, no significance claim at N=4 — §1.3); correction rounds against 3/1/2/1/2/2; **greens by
+bar, no significance claim at N=6 — §1.3); correction rounds against 3/1/2/1/2/2; **greens by
 repair versus by re-dispatch**, counted separately; refused versus applied patches per roll
 (new); `stores_beyond_roots`; qa primary completion tokens against 1.6.5's twelve.
 
@@ -103,7 +110,7 @@ stop early. A stop in one set does not stop the other.
 
 ---
 
-## 4. Next.js+TS (`nextjs_ts`) — the regression arm, four rolls
+## 4. Next.js+TS (`nextjs_ts`) — the regression arm, two rolls
 
 Nothing in the pack should reach this stack: A is the Python model emitter, B the React
 harness, E a manifest shape no Next.js manifest has used (and its output is byte-identical
@@ -130,7 +137,7 @@ prediction it registered.
 ## 5. Delegation
 
 Executed by the assistant under the owner's standing delegation for both sets — FastAPI+React
-rolls 1–4, then Next.js+TS rolls 1–4: launch, gate approval with the §6 constant, collection,
+rolls 1–6, then Next.js+TS rolls 1–2: launch, gate approval with the §6 constant, collection,
 and the per-roll record; **the counted/void/reset reading and the prediction check are made at
 each roll boundary before the next launch**; a reset or a falsified prediction stops that set
 for the owner. No merges to main while either set is open (§7).

--- a/docs/plans/1-6-6-verification-set-preregistration.md
+++ b/docs/plans/1-6-6-verification-set-preregistration.md
@@ -1,0 +1,145 @@
+# 1.6.6 — Verification Sets: Pre-registration
+
+**In force from roll 1, by the commit hash of this document on its branch, and unchanged
+thereafter.** Written 2026-08-27 (afternoon ET), after the rebuild on the merged 1.6.6 pack and
+after both shakeouts, before the first counted launch. Merging it is the owner's act and does
+not change what it pre-registers; the branch commit is the record.
+
+This is the 1.6.6 plan's §3 (`docs/plans/1-6-6-plan.md`, rev 1) with one change the owner
+made on 2026-08-27: **two counting sets of four, not one of six** — the FastAPI+React set that
+measures the pack, and a Next.js+TS regression arm that asks only whether anything moved.
+Everything not restated here is inherited **verbatim** from the 1.6.5 pre-registration
+(`docs/plans/1-6-5-verification-set-preregistration.md`) and, through it, 1.6.4 and 1.6.3:
+§5 (scoring), §5.1 (roll validity — void / reset / counted), §6 and §6.1 (the gate constant
+and the two approval paths), §7 (prohibited while open).
+
+**The instrument moved with the pack.** The driver (`scripts/dev/verification_set_driver.py`)
+gained the readouts the 1.6.6 plan §2.3 promised, so R1, R2, R4 and R5 below are read from the
+per-roll record rather than from a log by hand: the React P0 asserts every optional field froze
+nullable; the loop texture banks refused and applied patches and `plan_defect_after_zero_applied`;
+the static checks bank empty POST bodies and "Found multiple elements" reports. Every fixed
+parameter is read from `docs/plans/verification-sets/1-6-6-fastapi-react.yaml` and
+`docs/plans/verification-sets/1-6-6-nextjs.yaml` — the pins there and in §1 are the same values,
+written once; the driver refuses a counting roll when the deploy's image ids or HEAD differ.
+
+---
+
+## 1. Fixed parameters
+
+| Parameter | Value |
+|---|---|
+| N (rolls) | **4 counted** on FastAPI+React (the measurement, §3) and **4 counted** on Next.js+TS (the regression arm, §4). See §1.3 for what N=4 can and cannot say. |
+| Bar | **none** on either rate; each prediction is pass/fail on its own terms |
+| Project / PRD / squad / request profile | `group_run`, `full-38`, `validated-fullstack` — identical to 1.6.5 |
+| Overrides | FastAPI+React: none (`validated-fullstack`'s defaults are stack #1). Next.js+TS: `build_profile=nextjs_ts`, `dev_capability=nextjs_ts` |
+| `resolved_config_hash` | FastAPI+React `c4d6a2165acf`, Next.js+TS `d4d4f66217d8` — **unchanged** from 1.6.5: the pack changed code, not configuration; a roll on any other hash is void |
+| `squad_profile_snapshot_ref` | `575707c58536cf3b…` — unchanged from 1.6.5 (E's eve budget still in force); a roll on any other snapshot is void |
+| Deploy — commit | `__DEPLOY_COMMIT__` (main at the #1141 merge: A #1136, B #1137, F #1138, C #1139, D #1140, E #1141) |
+| Deploy — 7 image ids | `__IMAGE_IDS__` — asserted at every counting launch by the driver |
+| Loaded, not built | verified in-container by the driver's `loaded_checks` before both shakeouts and recorded with the deploy identity: runtime-api carries `REPAIR_REFUSED_MARKER` / `repair_refused_in_round` (D), `supersede_evidence_artifacts` (F), `InterfaceManifest.request_body_fields` / `request_model_name` (E) and `app_invocation_for` (C); eve carries `AppInvocation` and both stacks' declarations (C). A and B are frozen-output changes read by P0 (R1) and the shakeout's stored harness. |
+| Gate policy | 1.6.3 §6 constant, verbatim in each set config's `gate_notes`; `--as-agent`; both §6.1 paths satisfy zero-intervention and the decider is recorded per roll |
+| Audit instrument | `scripts/dev/audit_delivered_app.py` at the frozen deploy commit |
+| Driver | `verification_set_driver.py roll --set docs/plans/verification-sets/1-6-6-fastapi-react.yaml --roll N`, then `…/1-6-6-nextjs.yaml` — one roll per invocation |
+| Order | FastAPI+React rolls 1–4 first (the measurement), then Next.js+TS rolls 1–4 |
+
+### 1.3 The honest limits of N=4
+
+Four rolls per arm is the owner's sizing, and this section says what it buys and what it
+does not. **It buys the mechanism questions**: every prediction in §3 and §4 is pass/fail per
+roll, and one falsification is a finding at N=1 — that is what stopped the previous sets early
+and it works at any N. **It does not buy a rate**: 4 of 4 is 95% CI [51%, 100%] (Wilson); 2 of
+4 is [9.5%, 90.5%]. Against the 1.6.5 FastAPI+React baseline of 2 of 6 ([9.7%, 70.0%]) no
+outcome of four rolls can claim a significant change, and this document does not. Against
+the Next.js 6 of 6, four greens say "nothing moved" and one red is one red — a finding to
+attribute, not a rate. The verdict counts are reported with their intervals and no bar.
+
+---
+
+## 2. Preconditions
+
+- **Both shakeouts on THIS deploy read, before roll 1** — `__SHAKEOUT_FASTAPI__` (FastAPI+React)
+  and `__SHAKEOUT_NEXTJS__` (Next.js+TS). A shakeout is non-counting by declaration before
+  launch; what it must show is that the pack is *loaded and exercised where the manifest
+  gives it the chance*: on FastAPI+React the frozen `models.py` optional fields nullable (R1's
+  P0 row) and no "Found multiple elements" in any report (R2); on Next.js+TS byte-identical
+  behaviour to 1.6.5 (Q0/Q5/P0 as recorded there). If either shakeout falsifies one of its
+  arm's predictions, the set does not open and the failure is the first finding.
+- Leases 0, nothing in flight, HEAD pinned at the deploy commit, working tree clean, at
+  every launch (driver preflight).
+- **No merges to main while either set is open** (§7 of 1.6.3). The instrumentation PR that
+  carries this document and the set configs is merged **before** roll 1; the driver pins HEAD
+  at roll 1.
+
+---
+
+## 3. FastAPI+React (`fullstack_fastapi_react`) — the measurement, four rolls
+
+The set the 1.6.6 pack was built for. Every prediction is one item of the pack, read only from
+the evidence named, and each has a 1.6.5 roll that falsified it before the fix:
+
+| # | prediction | falsified by | read from | 1.6.5 evidence |
+|---|---|---|---|---|
+| **R1** | (A #1125) no frozen entity field is emitted non-nullable with a `None` default | the driver's P0 `models_nullable_mismatches` non-empty, or one `string_type … input_value=None` on a frozen field in any per-round `test_report.md` | driver `static_checks.p0` (asserted per roll); per-round reports | rolls 1, 2, 4, 5, 6 |
+| **R2** | (B #1127) no stored frontend report fails "Found multiple elements" | `static_checks.multiple_elements_reports` non-empty | driver record | roll 1 |
+| **R3** | (C #1126) no suite that imports `App` or a view component is failed by `no_self_mocking_tests` | one `handler_failed` on a `qa.test` whose own report passed, with `no_self_mocking_tests` offenders naming a suite that imports `App`/`views/` | eve log + the stored suite (by hand — the one prediction the record cannot read alone) | roll 1 |
+| **R4** | (D #1129) no run terminates `plan_defect` with zero applied patches | `loop_texture.plan_defect_after_zero_applied` true | driver record | rolls 5, 6 |
+| **R5** | (E #1128) no POST probe on an endpoint that declares a `request:` carries `json: {}` | `static_checks.empty_body_probes` non-empty | driver record | roll 3 |
+| **R6** | (F #1111) after a passing retest, the qa task's stored `test_report.md` is the passing one | a failed `test_report.md` stored under the task id later than a passing retest report for the same task | artifact vault timestamps (by hand); `loop_texture.evidence_superseded` is the positive trace | roll 1 |
+| **S0–S3, Q3** | carried from 1.6.5 §4 unchanged | as there | as there | held 6/6 |
+
+**Texture, no prediction attached:** the verdict rate against 2 of 6 (Wilson interval, no
+bar, no significance claim at N=4 — §1.3); correction rounds against 3/1/2/1/2/2; **greens by
+repair versus by re-dispatch**, counted separately; refused versus applied patches per roll
+(new); `stores_beyond_roots`; qa primary completion tokens against 1.6.5's twelve.
+
+**What this arm cannot read:** anything about a repair that is never attempted. A roll whose
+manifest omits `default: null` never exercises A (three of nine 1.6.5-era manifests did), and a
+roll with zero correction rounds exercises none of D or F. Unexercised is not passed; each
+roll's record says which predictions it exercised.
+
+**Early stop, one direction.** A falsified R1–R6 (or S0–S3/Q3) stops this set: the fix did
+not work and the remaining rolls teach nothing about it. A good result is never grounds to
+stop early. A stop in one set does not stop the other.
+
+---
+
+## 4. Next.js+TS (`nextjs_ts`) — the regression arm, four rolls
+
+Nothing in the pack should reach this stack: A is the Python model emitter, B the React
+harness, E a manifest shape no Next.js manifest has used (and its output is byte-identical
+on the pinned reference), and C/D/F are loop code the 1.6.5 Next.js set never executed (zero
+correction rounds). The arm exists because "should not" is the claim under test — the 1.6.5
+finding F1 was exactly a check written for one stack reaching the other.
+
+| # | prediction | falsified by | read from |
+|---|---|---|---|
+| **Q0** | every `qa.test` primary emission places all fill fences before any additive file | one emission with an additive file ahead of a fill | LangFuse generation output (first fill fence index < first path fence) |
+| **Q5** | no `qa.test` primary emission reaches the 12,288 cap | one primary at 12,288 | eve `emission shape … completion_tokens=` |
+| **P0** | the seeded frozen tree agrees with the floor | the driver's P0 `FALSIFIED` | driver `static_checks.p0` |
+| **Coverage** | an accepted roll credits every criterion | `criteria_verified < criteria_total` on an accepted roll | `run_verification_summaries` |
+| **C on Next.js** | a suite that imports an `app/api/` route module with `fetch` stubbed is still not flagged, and a suite that stubs `fetch` without one still is | either direction reversed on any roll that emits an additive suite | `no_self_mocking_tests` rows in `validation_result` + the stored suite |
+
+**Texture:** correction rounds against 0/0/0/0/0/0; if any roll enters the loop, D and F are
+read on it exactly as in §3 (R4, R6) and reported — as an observation on this arm, not as a
+prediction it registered.
+
+**Early stop, one direction, per set** — as §3.
+
+---
+
+## 5. Delegation
+
+Executed by the assistant under the owner's standing delegation for both sets — FastAPI+React
+rolls 1–4, then Next.js+TS rolls 1–4: launch, gate approval with the §6 constant, collection,
+and the per-roll record; **the counted/void/reset reading and the prediction check are made at
+each roll boundary before the next launch**; a reset or a falsified prediction stops that set
+for the owner. No merges to main while either set is open (§7).
+
+## 6. Gate constant
+
+Inherited verbatim (1.6.3 §6, §6.1); the text is in each set config's `gate_notes`.
+
+## 7. Prohibited while open
+
+Inherited verbatim (1.6.3 §7): no merges to main, no rebuilds, no config edits, no manual
+intervention on any roll; a rebuild voids every roll after it.

--- a/docs/plans/1-6-6-verification-set-preregistration.md
+++ b/docs/plans/1-6-6-verification-set-preregistration.md
@@ -34,8 +34,8 @@ written once; the driver refuses a counting roll when the deploy's image ids or 
 | Overrides | FastAPI+React: none (`validated-fullstack`'s defaults are stack #1). Next.js+TS: `build_profile=nextjs_ts`, `dev_capability=nextjs_ts` |
 | `resolved_config_hash` | FastAPI+React `c4d6a2165acf`, Next.js+TS `d4d4f66217d8` — **unchanged** from 1.6.5: the pack changed code, not configuration; a roll on any other hash is void |
 | `squad_profile_snapshot_ref` | `575707c58536cf3b…` — unchanged from 1.6.5 (E's eve budget still in force); a roll on any other snapshot is void |
-| Deploy — commit | `__DEPLOY_COMMIT__` (main at the #1141 merge: A #1136, B #1137, F #1138, C #1139, D #1140, E #1141) |
-| Deploy — 7 image ids | `__IMAGE_IDS__` — asserted at every counting launch by the driver |
+| Deploy — commit | `e14a6ad4` (main at the #1141 merge: A #1136, B #1137, F #1138, C #1139, D #1140, E #1141) |
+| Deploy — 7 image ids | runtime-api `5d6c78df37f4` · max `0b996c984c2a` · neo `577f8271178f` · nat `c4faec0cb1c6` · bob `90e0539eb041` · eve `248da1560551` · data `37e27803b5ed` — asserted at every counting launch by the driver |
 | Loaded, not built | verified in-container by the driver's `loaded_checks` before both shakeouts and recorded with the deploy identity: runtime-api carries `REPAIR_REFUSED_MARKER` / `repair_refused_in_round` (D), `supersede_evidence_artifacts` (F), `InterfaceManifest.request_body_fields` / `request_model_name` (E) and `app_invocation_for` (C); eve carries `AppInvocation` and both stacks' declarations (C). A and B are frozen-output changes read by P0 (R1) and the shakeout's stored harness. |
 | Gate policy | 1.6.3 §6 constant, verbatim in each set config's `gate_notes`; `--as-agent`; both §6.1 paths satisfy zero-intervention and the decider is recorded per roll |
 | Audit instrument | `scripts/dev/audit_delivered_app.py` at the frozen deploy commit |

--- a/docs/plans/verification-sets/1-6-6-fastapi-react.yaml
+++ b/docs/plans/verification-sets/1-6-6-fastapi-react.yaml
@@ -1,4 +1,4 @@
-# 1.6.6 verification set — FastAPI+React (fullstack_fastapi_react), 4 counting rolls: the set that
+# 1.6.6 verification set — FastAPI+React (fullstack_fastapi_react), 6 counting rolls: the set that
 # measures the 1.6.6 pack (A–F) against the 1.6.5 baseline of 2/6 on this stack. Predictions R1–R6
 # per the pre-registration. Same request profile and overrides as 1.6.5 (no config change in the
 # pack, so the same resolved_config_hash and squad snapshot are expected). Pins filled at
@@ -10,7 +10,7 @@ squad_profile: full-38
 request_profile: validated-fullstack
 overrides: {}
 gate_name: progress_plan_review
-n_rolls: 4
+n_rolls: 6
 gate_notes: >-
   1.6.6 FastAPI+React verification set. Approved under the pre-registered gate policy
   (pre-registration §6) — identical text applied to every roll of this set.

--- a/docs/plans/verification-sets/1-6-6-fastapi-react.yaml
+++ b/docs/plans/verification-sets/1-6-6-fastapi-react.yaml
@@ -1,0 +1,42 @@
+# 1.6.6 verification set — FastAPI+React (fullstack_fastapi_react), 4 counting rolls: the set that
+# measures the 1.6.6 pack (A–F) against the 1.6.5 baseline of 2/6 on this stack. Predictions R1–R6
+# per the pre-registration. Same request profile and overrides as 1.6.5 (no config change in the
+# pack, so the same resolved_config_hash and squad snapshot are expected). Pins filled at
+# pre-registration, after the shakeout, and asserted on every counting roll.
+name: 1-6-6-fastapi-react
+pre_registration: docs/plans/1-6-6-verification-set-preregistration.md
+project: group_run
+squad_profile: full-38
+request_profile: validated-fullstack
+overrides: {}
+gate_name: progress_plan_review
+n_rolls: 4
+gate_notes: >-
+  1.6.6 FastAPI+React verification set. Approved under the pre-registered gate policy
+  (pre-registration §6) — identical text applied to every roll of this set.
+  System plan validation passed; no additional judgment applied.
+launch_notes: >-
+  1.6.6 FastAPI+React verification set — COUNTED roll {roll} of {n} on
+  fullstack_fastapi_react. Frozen deploy per the pre-registration; predictions R1–R6 (the 1.6.6 pack) with
+  S0–S3 carried; the 1.6.5 baseline is 2/6; scoring per 1.6.3 §5; validity per §5.1.
+shakeout_notes: >-
+  1.6.6 FastAPI+React SHAKEOUT — NON-COUNTING by declaration before launch. First cycle on the
+  deploy carrying 1.6.6 A–F (#1136 #1137 #1138 #1139 #1140 #1141), the pack built from this
+  stack's 1.6.5 reds. Diagnostic only, not a measurement.
+loaded_checks:
+  runtime-api: >-
+    from squadops.cycles.correction_signature import REPAIR_REFUSED_MARKER, repair_refused_in_round;
+    from squadops.cycles.patch_verification import supersede_evidence_artifacts;
+    from squadops.capabilities.scaffold import InterfaceManifest, app_invocation_for;
+    print(InterfaceManifest.request_body_fields.__name__, InterfaceManifest.request_model_name.__name__,
+    app_invocation_for('fullstack_fastapi_react') is not None, REPAIR_REFUSED_MARKER[:15])
+  eve: >-
+    from squadops.capabilities.app_invocation import AppInvocation;
+    from squadops.capabilities.scaffold import app_invocation_for;
+    from squadops.capabilities.handlers.stub_detection import detect_self_mocking_tests;
+    print(app_invocation_for('nextjs_ts') is not None, app_invocation_for('fullstack_fastapi_react') is not None)
+expected_config_hash_prefix: "c4d6a2165acf"
+# The identity a per-agent override moves (1.6.5 E) — resolved_config_hash does not see it.
+expected_squad_snapshot_prefix: "575707c58536cf3b"
+frozen_deploy_commit: ""
+frozen_image_ids: {}

--- a/docs/plans/verification-sets/1-6-6-fastapi-react.yaml
+++ b/docs/plans/verification-sets/1-6-6-fastapi-react.yaml
@@ -38,5 +38,12 @@ loaded_checks:
 expected_config_hash_prefix: "c4d6a2165acf"
 # The identity a per-agent override moves (1.6.5 E) — resolved_config_hash does not see it.
 expected_squad_snapshot_prefix: "575707c58536cf3b"
-frozen_deploy_commit: ""
-frozen_image_ids: {}
+frozen_deploy_commit: "e14a6ad4"
+frozen_image_ids:
+  runtime-api: 5d6c78df37f4
+  max: 0b996c984c2a
+  neo: 577f8271178f
+  nat: c4faec0cb1c6
+  bob: 90e0539eb041
+  eve: 248da1560551
+  data: 37e27803b5ed

--- a/docs/plans/verification-sets/1-6-6-nextjs.yaml
+++ b/docs/plans/verification-sets/1-6-6-nextjs.yaml
@@ -42,5 +42,12 @@ loaded_checks:
 expected_config_hash_prefix: "d4d4f66217d8"
 # The identity a per-agent override moves (1.6.5 E) — resolved_config_hash does not see it.
 expected_squad_snapshot_prefix: "575707c58536cf3b"
-frozen_deploy_commit: ""
-frozen_image_ids: {}
+frozen_deploy_commit: "e14a6ad4"
+frozen_image_ids:
+  runtime-api: 5d6c78df37f4
+  max: 0b996c984c2a
+  neo: 577f8271178f
+  nat: c4faec0cb1c6
+  bob: 90e0539eb041
+  eve: 248da1560551
+  data: 37e27803b5ed

--- a/docs/plans/verification-sets/1-6-6-nextjs.yaml
+++ b/docs/plans/verification-sets/1-6-6-nextjs.yaml
@@ -1,0 +1,46 @@
+# 1.6.6 verification set — the REGRESSION arm on Next.js (nextjs_ts), 4 counting rolls. Items A/B/E leave
+# this stack's output byte-identical and C/D/F are loop code its 1.6.5 set never executed, so this arm
+# asks only that nothing moved: Q0/Q5/P0/coverage carried from 1.6.5. Pins are filled in at
+# pre-registration, after the shakeout, and asserted on every counting roll.
+name: 1-6-6-nextjs
+pre_registration: docs/plans/1-6-6-verification-set-preregistration.md
+project: group_run
+squad_profile: full-38
+request_profile: validated-fullstack
+overrides:
+  build_profile: nextjs_ts
+  dev_capability: nextjs_ts
+gate_name: progress_plan_review
+n_rolls: 4
+# Copied verbatim onto every gate approval — the driver substitutes NOTHING in this text.
+gate_notes: >-
+  1.6.6 verification set. Approved under the pre-registered gate policy
+  (pre-registration §6) — identical text applied to every roll of this set.
+  System plan validation passed; no additional judgment applied.
+# {roll} and {n} are the only substitutions the driver makes.
+launch_notes: >-
+  1.6.6 verification set — COUNTED roll {roll} of {n}. Frozen deploy per the
+  pre-registration; REGRESSION arm — predictions Q0/Q5/P0/coverage carried from 1.6.5;
+  scoring per 1.6.3 §5; validity per §5.1.
+shakeout_notes: >-
+  1.6.6 SHAKEOUT — NON-COUNTING by declaration before launch. First Next.js cycle on the deploy
+  carrying 1.6.6 A–F (#1136 #1137 #1138 #1139 #1140 #1141). Regression arm: A/B/E do not touch
+  this stack's output; C/D/F are loop code. Diagnostic only, not a measurement.
+# "Loaded, not built": run inside the container and recorded with the deploy identity.
+loaded_checks:
+  runtime-api: >-
+    from squadops.cycles.correction_signature import REPAIR_REFUSED_MARKER, repair_refused_in_round;
+    from squadops.cycles.patch_verification import supersede_evidence_artifacts;
+    from squadops.capabilities.scaffold import InterfaceManifest, app_invocation_for;
+    print(InterfaceManifest.request_body_fields.__name__, InterfaceManifest.request_model_name.__name__,
+    app_invocation_for('fullstack_fastapi_react') is not None, REPAIR_REFUSED_MARKER[:15])
+  eve: >-
+    from squadops.capabilities.app_invocation import AppInvocation;
+    from squadops.capabilities.scaffold import app_invocation_for;
+    from squadops.capabilities.handlers.stub_detection import detect_self_mocking_tests;
+    print(app_invocation_for('nextjs_ts') is not None, app_invocation_for('fullstack_fastapi_react') is not None)
+expected_config_hash_prefix: "d4d4f66217d8"
+# The identity a per-agent override moves (1.6.5 E) — resolved_config_hash does not see it.
+expected_squad_snapshot_prefix: "575707c58536cf3b"
+frozen_deploy_commit: ""
+frozen_image_ids: {}

--- a/docs/plans/verification-sets/1-6-6-nextjs.yaml
+++ b/docs/plans/verification-sets/1-6-6-nextjs.yaml
@@ -1,4 +1,4 @@
-# 1.6.6 verification set — the REGRESSION arm on Next.js (nextjs_ts), 4 counting rolls. Items A/B/E leave
+# 1.6.6 verification set — the REGRESSION arm on Next.js (nextjs_ts), 2 counting rolls. Items A/B/E leave
 # this stack's output byte-identical and C/D/F are loop code its 1.6.5 set never executed, so this arm
 # asks only that nothing moved: Q0/Q5/P0/coverage carried from 1.6.5. Pins are filled in at
 # pre-registration, after the shakeout, and asserted on every counting roll.
@@ -11,7 +11,7 @@ overrides:
   build_profile: nextjs_ts
   dev_capability: nextjs_ts
 gate_name: progress_plan_review
-n_rolls: 4
+n_rolls: 2
 # Copied verbatim onto every gate approval — the driver substitutes NOTHING in this text.
 gate_notes: >-
   1.6.6 verification set. Approved under the pre-registered gate policy

--- a/scripts/dev/verification_set_driver.py
+++ b/scripts/dev/verification_set_driver.py
@@ -587,6 +587,7 @@ def _p0_fullstack_fastapi_react(manifest: Any, seeded: Reader) -> dict:
     models = seeded("backend/models.py") or ""
     store = seeded("backend/store.py") or ""
     expected, mismatches = [], []
+    nullable_expected, nullable_mismatches = [], []
     for entity in manifest.entities:
         for f in entity.fields:
             if f.type.strip().lower().startswith("list["):
@@ -594,6 +595,14 @@ def _p0_fullstack_fastapi_react(manifest: Any, seeded: Reader) -> dict:
                 expected.append(want)
                 if want not in models:
                     mismatches.append(want)
+            elif (not f.required) or (f.has_default and f.default is None):
+                # #1125 (1.6.6 A, prediction R1): an optional field — declared
+                # ``required: false`` or ``default: null`` — freezes nullable. The
+                # ``str = None`` form pydantic rejects sat under five of six 1.6.5 rolls.
+                want = f"{f.name}: {_py_type(f.type)} | None = None"
+                nullable_expected.append(want)
+                if want not in models:
+                    nullable_mismatches.append(want)
     roots = list(root_persisted_entities(manifest))
     stores = re.findall(r"^(\w+)_store:", store, re.M)
     return {
@@ -602,10 +611,13 @@ def _p0_fullstack_fastapi_react(manifest: Any, seeded: Reader) -> dict:
         "models_expected_collection_lines": expected,
         "models_mismatches": mismatches,
         "p0_models_entity_typed": not mismatches,
+        "models_nullable_expected_lines": nullable_expected,
+        "models_nullable_mismatches": nullable_mismatches,
+        "p0_optional_fields_nullable": not nullable_mismatches,
         "store_names": stores,
         "root_persisted_entities": roots,
         "stores_beyond_roots": sorted(set(stores) - {_snake(r) for r in roots}),
-        "passed": not mismatches,
+        "passed": not mismatches and not nullable_mismatches,
     }
 
 
@@ -662,7 +674,51 @@ def static_checks(
     if framing_run:
         contract = artifact_text(cfg, cycle_id, framing_run, "verification_contract.yaml")
         out["contract_json_has_probes"] = contract.count("json_has:") if contract else None
+        # 1.6.6 R5 (#1128): no POST probe on an endpoint that declares a request body ships {}.
+        out["empty_body_probes"] = (
+            empty_body_probes(manifest, contract) if contract and manifest is not None else None
+        )
+    if impl_run:
+        # 1.6.6 R2 (#1127): no stored report fails "Found multiple elements".
+        out["multiple_elements_reports"] = _report_scan(
+            cfg, cycle_id, impl_run, "Found multiple elements"
+        )
     return out
+
+
+def empty_body_probes(manifest: Any, contract_text: str) -> list[str]:
+    """Ids of POST probes that carry ``json: {}`` on an endpoint whose manifest declares a
+    ``request:`` — the shape that made 1.6.5 FastAPI+React roll 3 unsatisfiable (#1128)."""
+    paths_with_request = {ep.path for ep in manifest.api.endpoints if ep.request}
+    try:
+        contract = yaml.safe_load(contract_text) or {}
+    except yaml.YAMLError:
+        return ["<contract unparseable>"]
+    probes = ((contract.get("behavioral") or {}).get("probes")) or []
+    return [
+        str(p.get("id"))
+        for p in probes
+        if isinstance(p, dict)
+        and (p.get("request") or {}).get("method") == "POST"
+        and (p.get("request") or {}).get("path") in paths_with_request
+        and (p.get("request") or {}).get("json") == {}
+    ]
+
+
+def _report_scan(cfg: SetConfig, cycle_id: str, impl_run: str, needle: str) -> list[str]:
+    """Task ids whose stored ``test_report.md`` contains ``needle`` (per-round evidence, #1127)."""
+    hits: list[str] = []
+    for art in artifact_dirs(cfg, cycle_id, impl_run):
+        m = _metadata(art)
+        if not m or str(m.get("filename", "")) != "test_report.md":
+            continue
+        try:
+            text = (REPO / m["vault_uri"]).read_text()
+        except (OSError, KeyError):
+            continue
+        if needle in text:
+            hits.append(str((m.get("metadata") or {}).get("task_id") or art.name))
+    return sorted(hits)
 
 
 def ledger_checks(rec: dict) -> dict:
@@ -687,12 +743,41 @@ def runtime_log_window(since: str) -> list[str]:
         "correction_terminated",
         "self_eval fills",
         "fill merge",
+        "patch_verification task=",
+        "patch_retest task=",
+        "plan_defect terminal",
+        "evidence superseded",
     )
     return [line for line in out.splitlines() if any(k in line for k in keys)]
 
 
 def loop_texture(cfg: SetConfig, cycle_id: str, impl_run: str | None, since: str) -> dict:
     logs = runtime_log_window(since)
+    out = texture_from_logs(logs)
+    out["fill_rejections"] = _fill_rejections(cfg, cycle_id, impl_run) if impl_run else []
+    return out
+
+
+def texture_from_logs(logs: list[str]) -> dict:
+    """The loop's readouts from the runtime-api log window — pure, so the parse is testable.
+
+    1.6.6 (plan §2.3): ``refused_patches`` (patch verification refused the repair — never
+    applied), ``applied_patches`` (a retest ran, or verification passed), and
+    ``plan_defect_after_zero_applied`` — prediction R4's falsifier, readable from the
+    record instead of the executor log. ``refused_rounds_not_counted`` is D's own line;
+    ``evidence_superseded`` is F's (#1111).
+    """
+    refused = [
+        line[-200:]
+        for line in logs
+        if "patch_verification task=" in line and "status=failed" in line
+    ]
+    applied = sum(
+        ("patch_retest task=" in line)
+        or ("patch_verification task=" in line and "status=passed" in line)
+        for line in logs
+    )
+    terminations = [line[-200:] for line in logs if "correction_terminated_plan_defect" in line]
     return {
         "narrowed_targets": [
             line.split("correction_repair_target:")[-1][:160]
@@ -709,7 +794,14 @@ def loop_texture(cfg: SetConfig, cycle_id: str, impl_run: str | None, since: str
             line[-160:] for line in logs if "repair emitted no content" in line
         ],
         "self_eval_fill_merges": [line[-160:] for line in logs if "self_eval fills" in line],
-        "fill_rejections": _fill_rejections(cfg, cycle_id, impl_run) if impl_run else [],
+        "refused_patches": refused,
+        "applied_patches": applied,
+        "plan_defect_terminations": terminations,
+        "plan_defect_after_zero_applied": bool(terminations) and applied == 0,
+        "refused_rounds_not_counted": [
+            line[-200:] for line in logs if "not counted as a repeat (#1129)" in line
+        ],
+        "evidence_superseded": [line[-200:] for line in logs if "evidence superseded" in line],
     }
 
 

--- a/tests/unit/cycles/test_verification_set_driver.py
+++ b/tests/unit/cycles/test_verification_set_driver.py
@@ -323,8 +323,8 @@ class TestSquadSnapshotIsAnIdentity:
         [
             ("1-6-5-nextjs.yaml", 6),
             ("1-6-5-fastapi-react.yaml", 6),
-            ("1-6-6-nextjs.yaml", 4),
-            ("1-6-6-fastapi-react.yaml", 4),
+            ("1-6-6-nextjs.yaml", 2),
+            ("1-6-6-fastapi-react.yaml", 6),
         ],
     )
     def test_the_counting_sets_are_fully_pinned(self, driver, filename, n):

--- a/tests/unit/cycles/test_verification_set_driver.py
+++ b/tests/unit/cycles/test_verification_set_driver.py
@@ -318,23 +318,32 @@ class TestSquadSnapshotIsAnIdentity:
     def test_identity_mismatch(self, driver, expected, actual, mismatch):
         assert driver.identity_mismatch(expected, actual) is mismatch
 
-    @pytest.mark.parametrize("filename", ["1-6-5-nextjs.yaml", "1-6-5-fastapi-react.yaml"])
-    def test_the_counting_sets_are_fully_pinned(self, driver, filename):
+    @pytest.mark.parametrize(
+        ("filename", "n"),
+        [
+            ("1-6-5-nextjs.yaml", 6),
+            ("1-6-5-fastapi-react.yaml", 6),
+            ("1-6-6-nextjs.yaml", 4),
+            ("1-6-6-fastapi-react.yaml", 4),
+        ],
+    )
+    def test_the_counting_sets_are_fully_pinned(self, driver, filename, n):
         """Bug caught: a counting set whose config still carries the shakeout-time blanks —
         the driver would then record instead of assert, and a rebuild mid-set would pass."""
         import re
 
         cfg = driver.load_set_config(_SETS / filename)
-        assert cfg.n_rolls == 6
+        assert cfg.n_rolls == n
         assert re.fullmatch(r"[0-9a-f]{12,16}", cfg.expected_squad_snapshot_prefix)
         assert re.fullmatch(r"[0-9a-f]{12}", cfg.expected_config_hash_prefix)
         assert re.fullmatch(r"[0-9a-f]{8}", cfg.frozen_deploy_commit)
         assert set(cfg.frozen_image_ids) == set(driver.DEPLOY_SERVICES)
         assert all(re.fullmatch(r"[0-9a-f]{12}", v) for v in cfg.frozen_image_ids.values())
 
-    def test_both_sets_share_the_deploy_and_snapshot_but_not_the_config_hash(self, driver):
-        a = driver.load_set_config(_SETS / "1-6-5-nextjs.yaml")
-        b = driver.load_set_config(_SETS / "1-6-5-fastapi-react.yaml")
+    @pytest.mark.parametrize("line", ["1-6-5", "1-6-6"])
+    def test_both_sets_share_the_deploy_and_snapshot_but_not_the_config_hash(self, driver, line):
+        a = driver.load_set_config(_SETS / f"{line}-nextjs.yaml")
+        b = driver.load_set_config(_SETS / f"{line}-fastapi-react.yaml")
         assert a.frozen_image_ids == b.frozen_image_ids
         assert a.frozen_deploy_commit == b.frozen_deploy_commit
         assert a.expected_squad_snapshot_prefix == b.expected_squad_snapshot_prefix

--- a/tests/unit/cycles/test_verification_set_driver.py
+++ b/tests/unit/cycles/test_verification_set_driver.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+from tests.unit.capabilities._stack_fixtures import manifest_dict_for_stack, manifest_for_stack
 
 pytestmark = [pytest.mark.domain_cycles]
 
@@ -117,6 +117,8 @@ class TestSetConfig:
         [
             ("1-6-5-nextjs.yaml", "nextjs_ts"),
             ("1-6-5-fastapi-react.yaml", "fullstack_fastapi_react"),
+            ("1-6-6-nextjs.yaml", "nextjs_ts"),
+            ("1-6-6-fastapi-react.yaml", "fullstack_fastapi_react"),
         ],
     )
     def test_the_committed_set_configs_load_and_derive_their_stack(self, driver, filename, stack):
@@ -191,6 +193,94 @@ class TestP0PerStack:
         assert out["passed"] is False and out["models_mismatches"] == [
             "participants: list[Participant]"
         ]
+
+    def test_stack1_p0_asserts_optional_fields_freeze_nullable(self, driver):
+        """1.6.6 R1 (#1125): a field the manifest declares ``required: false, default: null``
+        must freeze ``X | None = None``. Five of six 1.6.5 rolls opened on the ``str = None``
+        form; the driver read them as P0 held because nothing asserted this."""
+        import squadops.capabilities.scaffold as sc
+
+        raw = manifest_dict_for_stack("fullstack_fastapi_react")
+        for ent in raw["entities"]:
+            for f in ent["fields"]:
+                if f["name"] == "distance":
+                    f["required"], f["default"] = False, None
+        m = sc.InterfaceManifest.from_dict(raw)
+        out = driver.p0_checks(
+            "fullstack_fastapi_react", m, _seeded_reader("fullstack_fastapi_react", m)
+        )
+        assert out["passed"] is True
+        assert "distance: str | None = None" in out["models_nullable_expected_lines"]
+
+        def tamper(files):
+            return {
+                "backend/models.py": files["backend/models.py"].replace(
+                    "distance: str | None = None", "distance: str = None"
+                )
+            }
+
+        out = driver.p0_checks(
+            "fullstack_fastapi_react", m, _seeded_reader("fullstack_fastapi_react", m, tamper)
+        )
+        assert out["passed"] is False
+        assert out["models_nullable_mismatches"] == ["distance: str | None = None"]
+        assert out["p0_optional_fields_nullable"] is False
+
+
+class TestTextureFromLogs:
+    """1.6.6 R4 (#1129): the record must say whether a plan_defect termination followed
+    ANY applied patch — rolls 5 and 6 read as "the loop failed to converge" from the roll-up
+    and as "the loop never applied a patch" from the executor log."""
+
+    _REFUSED = "patch_verification task=t status=failed reason=unresolved_imports checks=4"
+    _PASSED = "patch_verification task=t status=passed reason= checks=4"
+    _RETEST = "patch_retest task=t status=FAILED passed=False reason=x"
+    _TERM = "correction_terminated_plan_defect task=t rounds=0..1 candidate=tighten_acceptance"
+
+    def test_roll_five_shape_is_a_termination_after_zero_applied(self, driver):
+        out = driver.texture_from_logs([self._REFUSED, self._TERM])
+        assert out["applied_patches"] == 0
+        assert len(out["refused_patches"]) == 1
+        assert out["plan_defect_after_zero_applied"] is True
+
+    def test_a_retest_counts_as_an_applied_patch(self, driver):
+        out = driver.texture_from_logs([self._PASSED, self._RETEST, self._TERM])
+        assert out["applied_patches"] == 2
+        assert out["plan_defect_after_zero_applied"] is False
+
+    def test_no_termination_is_never_the_falsifier(self, driver):
+        out = driver.texture_from_logs([self._REFUSED, self._REFUSED])
+        assert out["plan_defect_terminations"] == []
+        assert out["plan_defect_after_zero_applied"] is False
+
+    def test_d_and_f_lines_are_banked(self, driver):
+        out = driver.texture_from_logs(
+            [
+                "plan_defect terminal: round 0's repair … not counted as a repeat (#1129)",
+                "patch_retest task=t evidence superseded by the passing retest: replaced=a dropped=b (#1111)",
+            ]
+        )
+        assert len(out["refused_rounds_not_counted"]) == 1
+        assert len(out["evidence_superseded"]) == 1
+
+
+class TestEmptyBodyProbes:
+    """1.6.6 R5 (#1128): a POST probe on an endpoint that declares a request body must not
+    ship ``json: {}`` — roll 3's contract did, and was unsatisfiable by construction."""
+
+    def test_the_roll_three_shape_is_named_and_a_filled_body_is_not(self, driver):
+        m = manifest_for_stack("fullstack_fastapi_react")
+        contract = (
+            "behavioral:\n  probes:\n"
+            "    - id: vc-probe-runs\n      request: {method: POST, path: /runs, json: {title: x}}\n"
+            "    - id: vc-probe-runs-join\n      request: {method: POST, path: '/runs/{run_id}/join', json: {}}\n"
+            "    - id: vc-probe-runs-blank\n      request: {method: POST, path: /nowhere, json: {}}\n"
+        )
+        assert driver.empty_body_probes(m, contract) == ["vc-probe-runs-join"]
+
+    def test_an_unparseable_contract_is_visible_not_silent(self, driver):
+        m = manifest_for_stack("fullstack_fastapi_react")
+        assert driver.empty_body_probes(m, "behavioral: [unclosed") == ["<contract unparseable>"]
 
 
 class TestRunRows:


### PR DESCRIPTION
## Summary

**The 1.6.6 verification sets — 6 + 2, pre-registered** (resized from a 4+4 draft on the owner's ruling: six where the pack came from, two to show Next.js did not move), plus the driver readouts the 1.6.6 plan §2.3 promised, plus the two pinned set configs. Rolls run only after this merges (the driver pins HEAD at roll 1).

**Design (owner's sizing: 6 + 2).**
- `docs/plans/1-6-6-verification-set-preregistration.md` — **FastAPI+React, 6 counting rolls, the measurement**: R1–R6 are the six pack items, each with the 1.6.5 roll that falsified it before the fix and the exact record field that falsifies it now; S0–S3/Q3 carried. **Next.js+TS, 2 counting rolls, the regression arm**: Q0/Q5/P0/coverage carried from 1.6.5 plus one new check — C's Next.js definition must still flag/pass exactly as before. §1.3 states what 6 and 2 buy (six = more of the pack exercised, one falsification = a finding at N=1; two = "nothing moved" or one red to attribute) and do not (a rate: 6/6 is [61%, 100%], 3/6 is [19%, 81%]; no significance claim against 2/6 or 6/6). Early stop one-direction, per set. Order: FastAPI+React first.
- `docs/plans/verification-sets/1-6-6-fastapi-react.yaml`, `1-6-6-nextjs.yaml` — n_rolls 6 and 2, pinned to deploy `e14a6ad4` (main at #1141) and its seven image ids; loaded-checks now run in **runtime-api and eve** (C/D/E/F seams by name). Both preflights clean 15:36Z; loaded-checks printed `request_body_fields request_model_name True repair REJECTED` / `True True`.

**Instrument (`scripts/dev/verification_set_driver.py`):** the React P0 asserts every optional field froze nullable (R1's row, `models_nullable_mismatches`); `texture_from_logs` (pure, tested) banks `refused_patches`, `applied_patches`, `plan_defect_terminations`, **`plan_defect_after_zero_applied`** (R4's falsifier), D's and F's log lines; static checks bank `empty_body_probes` (R5, from the contract + manifest) and `multiple_elements_reports` (R2, from every stored `test_report.md`). 54 driver tests, incl. the 1.6.6 configs in the load/pinned/identity tests.

**Shakeouts:** FastAPI+React `cyc_1386b94dc688` launched 15:36Z on this deploy (running); Next.js+TS follows. Their ids and readings land in §2 by a follow-up commit before merge.

## Closes

No issue: pre-registration and instrument for the 1.6.6 sets. Refs #1125 #1126 #1127 #1128 #1129 #1111 (the pack under measurement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tj9vAj9yumEzAmBLrZnrX
