### PR TITLE
docs(plan): 1.6.6 pre-registration §2 — both shakeouts from main read; driver refused-patch readout per task

### DIFF
--- a/docs/plans/1-6-6-verification-set-preregistration.md
+++ b/docs/plans/1-6-6-verification-set-preregistration.md
@@ -64,13 +64,34 @@ is a rate; both are reported with their intervals and no bar.
 
 ## 2. Preconditions
 
-- **Both shakeouts on THIS deploy read, before roll 1** — `__SHAKEOUT_FASTAPI__` (FastAPI+React)
-  and `__SHAKEOUT_NEXTJS__` (Next.js+TS). A shakeout is non-counting by declaration before
-  launch; what it must show is that the pack is *loaded and exercised where the manifest
-  gives it the chance*: on FastAPI+React the frozen `models.py` optional fields nullable (R1's
-  P0 row) and no "Found multiple elements" in any report (R2); on Next.js+TS byte-identical
-  behaviour to 1.6.5 (Q0/Q5/P0 as recorded there). If either shakeout falsifies one of its
-  arm's predictions, the set does not open and the failure is the first finding.
+- **Both shakeouts on THIS deploy, launched from `main`, read before roll 1 — met, 2026-08-27:**
+  - **FastAPI+React `cyc_a217682f99dd`** (16:33→17:24Z, 49 min): accepted, audit PASS, 15/15, 0
+    corrections, gate by the §6 constant. Its manifest wrote `required: false, default: null` on
+    all three optional fields — the exact shape that opened five of six 1.6.5 rolls with a 500 —
+    and the frozen `models.py` reads `str | None = None`: **R1 exercised and held**
+    (`models_nullable_mismatches: []`). R2 clean, R5 clean (declared request shapes throughout,
+    so E was not exercised); D and F unexercised (no correction round); `run_summary` recorded
+    beyond the roots (#1087's open half, texture).
+  - **Next.js+TS `cyc_38f95b29cf79`** (17:24→19:01Z, 96 min): accepted, audit PASS, 15/15, Q0
+    held (first fill fence at 0, first path fence at 1,477), Q5 held (5,792 tokens), P0 held
+    (`TABLES = ['Run']`), coverage full — through **two correction rounds on a dev task** (a
+    TypeScript strict-null error in a page fill). Both repair patches came back `unverifiable`
+    (a `.tsx` file has no executable typed checks), the executor re-dispatched the task each
+    time, and the third emission compiled: **green by re-dispatch, none by repair.** D's branch
+    executed at round 1 (round 0's un-applied repair not counted as a repeat) — an *observation*
+    on the arm the pack was not supposed to reach, reported as §4 says; it was outcome-neutral
+    here because neither decision carried a structural candidate, so the `plan_defect` terminal
+    could not have fired regardless. F unexercised (no retest ran).
+  - **Instrument correction found by that roll:** the driver's `refused_patches` readout counted
+    only `status=failed`; an `unverifiable` verification followed by a re-dispatch is also a
+    patch never applied. The readout now reads the sequence per task (unverifiable → retest =
+    applied; unverifiable → re-dispatch = refused), so R4 is read from the corrected field.
+  - Two earlier shakeouts were launched from the pre-registration *branch* before the owner
+    ruled that every launch runs from `main` (FastAPI+React `cyc_1386b94dc688`, accepted 15/15,
+    R1 held; Next.js `cyc_aa6e02a2b665`, cancelled). Their records are kept as diagnostics and
+    are not this precondition.
+  A shakeout is non-counting by declaration before launch; had either falsified its arm's
+  predictions, the set would not have opened and the failure would be the first finding.
 - Leases 0, nothing in flight, HEAD pinned at the deploy commit, working tree clean, at
   every launch (driver preflight).
 - **No merges to main while either set is open** (§7 of 1.6.3). The instrumentation PR that

--- a/scripts/dev/verification_set_driver.py
+++ b/scripts/dev/verification_set_driver.py
@@ -745,6 +745,7 @@ def runtime_log_window(since: str) -> list[str]:
         "fill merge",
         "patch_verification task=",
         "patch_retest task=",
+        "Dispatched task task-",
         "plan_defect terminal",
         "evidence superseded",
     )
@@ -767,16 +768,32 @@ def texture_from_logs(logs: list[str]) -> dict:
     record instead of the executor log. ``refused_rounds_not_counted`` is D's own line;
     ``evidence_superseded`` is F's (#1111).
     """
-    refused = [
-        line[-200:]
-        for line in logs
-        if "patch_verification task=" in line and "status=failed" in line
-    ]
-    applied = sum(
-        ("patch_retest task=" in line)
-        or ("patch_verification task=" in line and "status=passed" in line)
-        for line in logs
-    )
+    # A patch is APPLIED when verification passed or a retest ran on it; it is REFUSED when
+    # verification failed, or came back unverifiable and the executor re-dispatched the task
+    # instead of retesting (a dev task with no executable typed checks — the Next.js 1.6.6
+    # shakeout's shape, which the first reading of this readout missed). Read sequentially
+    # per task so an unverifiable-then-retest pair counts once, as applied.
+    refused: list[str] = []
+    applied = 0
+    pending: dict[str, str] = {}  # task -> the unverifiable line awaiting its fate
+    for line in logs:
+        if "patch_verification task=" in line:
+            task = line.split("patch_verification task=", 1)[1].split()[0]
+            if "status=passed" in line:
+                applied += 1
+            elif "status=failed" in line:
+                refused.append(line[-200:])
+            elif "status=unverifiable" in line:
+                pending[task] = line[-200:]
+        elif "patch_retest task=" in line:
+            task = line.split("patch_retest task=", 1)[1].split()[0]
+            pending.pop(task, None)
+            applied += 1
+        elif "Dispatched task " in line:
+            task = line.split("Dispatched task ", 1)[1].split()[0]
+            if task in pending:
+                refused.append(pending.pop(task))
+    refused.extend(pending.values())
     terminations = [line[-200:] for line in logs if "correction_terminated_plan_defect" in line]
     return {
         "narrowed_targets": [

--- a/tests/unit/cycles/test_verification_set_driver.py
+++ b/tests/unit/cycles/test_verification_set_driver.py
@@ -248,6 +248,22 @@ class TestTextureFromLogs:
         assert out["applied_patches"] == 2
         assert out["plan_defect_after_zero_applied"] is False
 
+    def test_unverifiable_then_redispatch_is_a_refusal_but_unverifiable_then_retest_is_applied(
+        self, driver
+    ):
+        """The 1.6.6 Next.js shakeout (cyc_38f95b29cf79): both dev-task patches came back
+        unverifiable (no executable typed checks on a .tsx file) and the executor re-dispatched
+        the task — never applied — and the first reading counted refused=0."""
+        unver = (
+            "patch_verification task=task-a status=unverifiable reason=no_executed_blocking_checks"
+        )
+        redispatch = "Dispatched task task-a (development.develop) to neo_comms"
+        retest = "patch_retest task=task-b status=SUCCEEDED passed=True reason=ok"
+        unver_b = "patch_verification task=task-b status=unverifiable reason=no_typed_criteria"
+        out = driver.texture_from_logs([unver, redispatch, unver_b, retest])
+        assert len(out["refused_patches"]) == 1 and "task-a" in out["refused_patches"][0]
+        assert out["applied_patches"] == 1
+
     def test_no_termination_is_never_the_falsifier(self, driver):
         out = driver.texture_from_logs([self._REFUSED, self._REFUSED])
         assert out["plan_defect_terminations"] == []


### PR DESCRIPTION
## Summary

The precondition step of the 1.6.6 pre-registration: **both shakeouts on deploy `e14a6ad4`, launched from `main`, read before roll 1** (§2).

- **FastAPI+React `cyc_a217682f99dd`** — accepted, audit PASS, 15/15, 0 corrections, 49 min. Its manifest wrote `default: null` on all three optional fields (the 1.6.5 round-0 shape) and the frozen model is `str | None = None`: **R1 exercised and held.** R2/R5 clean; D/F unexercised.
- **Next.js+TS `cyc_38f95b29cf79`** — accepted, audit PASS, 15/15, Q0/Q5/P0/coverage held, through two correction rounds on a dev task (TypeScript strict-null in a page fill). Both patches `unverifiable` (no executable typed checks on `.tsx`), re-dispatched each time, third emission compiled — **green by re-dispatch, none by repair.** D's branch executed at round 1 (observation on the regression arm); outcome-neutral here since neither decision carried a structural candidate.
- **Instrument correction found by that roll:** the driver counted refused patches only on `status=failed`; `unverifiable` followed by a re-dispatch is also a patch never applied. `texture_from_logs` now reads the per-task sequence (unverifiable → retest = applied; unverifiable → re-dispatch = refused). Test added with the shakeout's shape; 39 driver tests green.
- The two earlier branch-launched shakeouts are recorded as diagnostics only, per the owner's ruling that every launch runs from `main`.

After merge: roll 1 of six on FastAPI+React, from `main`; the driver pins HEAD at that commit.

## Closes

No issue: pre-registration precondition record + instrument correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tj9vAj9yumEzAmBLrZnrX
