### PR TITLE
docs(plan): 1.7.0 rev 3 — name the 1.7.0 line (Reasoning), renumber 1.7.0–1.7.4, split the cut criteria

### DIFF
--- a/docs/plans/1-7-0-plan.md
+++ b/docs/plans/1-7-0-plan.md
@@ -9,7 +9,12 @@ as tagged lines — so **1.7.0 is the Reasoning line**, the one §3 already puts
 and the lines renumber 1.7.0–1.7.4. §6 splits into the 1.7.0 cut and the line's close. #1135
 moves to 1.7.0's rider (a rider may move to a neighbour; §6's package-capture criterion
 applies to every cut, so the script fix precedes the first one). The residual letter handles
-(S, L, B, C, H) that survived rev 1's rename are replaced with the pack names.
+(S, L, B, C, H) that survived rev 1's rename are replaced with the pack names. **Rev 3 also
+places Atlas** (§2.1a): the owner's ask of 2026-08-28 is to leverage Atlas's speed for
+wall-clock savings across many cycles, so the migration the SIP scheduled for 1.8+ moves to
+the earliest point its dependencies allow — #1157 (provider selection, required), #1158
+(Atlas on the Spark), #1159 (the adapter), #1160 (the A/B artifact) in 1.7.0's rider, and
+the switch itself as an owner decision on that artifact at a line boundary.
 
 **Revision 2, 2026-08-27.** Adds the findings of the owner's architectural assessment of
 `main` at `2448f5d1` (read the same evening; every claim acted on was re-verified against the
@@ -116,13 +121,74 @@ The owner's second ask, and the pack with the widest blast radius: it touches ev
   delete the dead `LLMRouter`** whose docstring claims it is wired. This is the Atlas seam:
   after it, a provider is an adapter behind one port with a characterization suite, and the
   status vocabulary in the port is ours.
+- **#1157 — the provider is selected by configuration, and the configuration is required.**
+  Two adapters are in the tree and nothing can select the second: the factory defaults
+  `provider="ollama"`, the agent entrypoint never passes one, `LLMConfig` has no field. The
+  SIP's P2 designed the field with a dormant default for the 1.6 windows' sake; that window
+  closed at v1.6.6 and the owner ruled the other way (2026-08-28): no default on the schema,
+  none on the factory, a missing value fails at config load, every deploy surface writes it.
+- **The reasoning dial kind is a model-spec fact, and the suite records every adapter.** #927
+  maps the level per provider *and per model family* (a Qwen3-class model toggles thinking,
+  gpt-oss takes an effort, an R1-class model has no control) — the model registry #1145
+  makes authoritative is where `reasoning_control` is declared, so no adapter matches model
+  names. #927 and #410 land on `vllm.py` as well as `ollama.py` (both declare
+  `THINKING_TOKENS: False` and read `content` only), and the characterization suite records
+  Ollama, vLLM and — once #1159 exists — Atlas.
 
 **How we know:** (1) the #924 probe replayed through the port — same brief, `none` vs `high`:
 the 413/5,727 split reproduced from our own telemetry, thinking text present in LangFuse on
 the `high` run; (2) one shakeout per stack with `none` on qa fill/repair and `high` on framing,
 asserting fills-first still holds (Q0) and the qa primary distribution moves down; (3) the
-adapter characterization suite runs in CI against a recorded Ollama transcript, so the mapping
-cannot regress unobserved.
+adapter characterization suite runs in CI against a recorded transcript per adapter in the
+tree, so no mapping regresses unobserved.
+
+#### 2.1a The seam's consumer — Atlas selectable, measured, and switched
+
+Atlas is a third-party inference engine tuned for the DGX Spark, OpenAI-shaped on port 8888,
+with a recipe for the model the `full` profile pins (`sips/proposed/SIP-Atlas-Provider-Adapter.md`
+§2.0 is its only record in the tree — and the SIP is one of #1144's unindexed 24). It is
+**not vLLM**: the `VLLMAdapter` (#805) is the SIP's optional control arm, P6. The SIP's own
+ledger: P0/P1 (#800), P3 (#799, #801) and P6 (#805) landed 2026-08-08; **P2 — provider
+selection, its headline deliverable — never did** (#1157); P4/P5 wait on a live endpoint.
+
+The owner's ask (2026-08-28) is to leverage Atlas's speed for wall-clock savings across many
+cycles, which moves the migration off the SIP's "1.8+" row to the earliest point its
+dependencies allow. Ruling 1 in the SIP already waives even/odd placement for this change;
+Ruling 2 already makes the switch a config change on observed results, not a gated event.
+What 1.7 adds is the order:
+
+- **#1158 — Atlas serving on the Spark**, bootstrap-installed on `local-spark` only,
+  container-reachable, and the SIP's remaining live-verification facts answered in writing
+  (streaming frame shape, model management, usage/duration fields, and a new fact 6: what
+  per-request reasoning control Atlas honors, which #927's mapping needs). Ops, no code
+  dependency — it starts now and is what unblocks P4.
+- **#1159 — the Atlas adapter** behind the port, one adapter per provider, capabilities
+  observed not assumed, implementing #927's level from the start — so after #927's port
+  change, not before.
+- **#1160 — the A/B artifact** the SIP's §3.6.1 specifies, produced on the Spark and
+  committed: `wall_clock_ms` per (prompt, model, adapter) as the decision field, decode t/s
+  as the diagnostic, one full cycle per arm on the `full` model — because the saving the
+  owner wants is across a six-agent box, not one generation's t/s. The number is reported,
+  not forecast.
+- **The switch** is not a pack item. It is the owner's decision on #1160's artifact, and
+  when taken it is one PR changing the value every deploy surface carries (there is no
+  default to flip after #1157) plus the SIP's §5 cutover row. It lands **at a line boundary,
+  never mid-set** — the §4.1 reason the SIP's dark-ship rule existed still holds *within* a
+  measurement: the earliest boundary is the 1.7.0 cut, so that 1.7.1's counting set is the
+  first to run on Atlas. Every later texture comparison against 1.6.6 then carries the
+  runner change as a named confound; the mechanism predictions (§4) do not depend on the
+  runner, and the token-distribution predictions are read on 1.7.0's Ollama shakeouts first.
+
+**Design gate before P4:** the SIP is still `proposed` and P0–P6 were implemented against it
+in that state. Before #1159 opens, the SIP is revised (§3.1/§4.1 required-not-defaulted;
+§5's cutover row; §10.2 fact 6) and goes to the acceptance decision — the workflow's step 3,
+so the adapter is built from an accepted spec.
+
+**How we know:** #1157's config fails to load without a provider and resolves `VLLMAdapter`
+and the Atlas adapter at *both* composition seams; #1159 passes the P3 conformance suite
+(the same contract Ollama passed); #1160's artifact exists with every field populated or
+declared `None`; and if the switch is taken, the first 1.7.1 preflight runs on Atlas and
+says so.
 
 ### 2.2 Pack **Stack Seams** — the stack seam and the correction loop's last red class
 
@@ -275,7 +341,8 @@ first capture already has it.
 - **#376** — SIP-0102 migration steps 3–7 (in-cycle final-state verification), deferred from 1.4.
 - **Design, not code:** #414 (severity-aware correction-budget reserve), #557 (post-retest
   governance acceptance review), #1122 + the Stack Blueprint rewrite (1.8-lane consumers of
-  #1131), #316 (request-profile taxonomy — moves with Campaign).
+  #1131), #316 (request-profile taxonomy — moves with Campaign), **the Atlas SIP's revision
+  and acceptance decision before #1159 opens (§2.1a)**.
 
 ### 2.8 Explicitly not in 1.7
 
@@ -294,7 +361,9 @@ By dependency and by what each pack proves, never by date:
 1. **Pack Reasoning first, alone.** It changes what every subsequent measurement means (a qa primary
    at 5,700 tokens today is mostly thinking). Land #927/#410 with the adapter suite, replay the
    #924 probe, run one shakeout per stack, and only then re-read every completion-budget
-   number in the codebase (#924's budget half, 1.6.5's E).
+   number in the codebase (#924's budget half, 1.6.5's E). **Atlas rides this line's rider
+   in order** (§2.1a): #1158 from day one, #1157 with the port work, #1159 after #927's port
+   change, #1160 when both exist; the switch, if taken, at the 1.7.0 cut.
 2. **Harvest, then move (#1149 → #1131) before Pack Stack Seams' fixes** — the rationale comes
    out of `scaffold.py` into a durable home first; then the pure move; then the kind gate, #1130
    and #1123 are written into the stack seam, not into the file it is leaving. The structural
@@ -339,16 +408,16 @@ are verified differently:
 
 | line | measured pack (roll-verified) | CI-verified rider |
 |---|---|---|
-| **1.7.0** | **Reasoning** — #927, #410, #924 (budget half), #1145, #930 — first and alone, because it changes what every later token number means | #901, #929, #944; the CI-truth items first: #1099, #242, #1041, #237; #1135 (the package capture credits `Closes` in code spans — fixed before the first capture) |
+| **1.7.0** | **Reasoning** — #927, #410, #924 (budget half), #1145, #930 — first and alone, because it changes what every later token number means | #901, #929, #944; the CI-truth items first: #1099, #242, #1041, #237; #1135 (the package capture credits `Closes` in code spans — fixed before the first capture); **Atlas** (§2.1a): #1157 (required provider), #1158 (Atlas on the Spark), #1159 (adapter, after #927), #1160 (A/B artifact) — #1159/#1160 move to 1.7.1's rider without touching the packs if #1158's facts are not in writing by the cut |
 | **1.7.1** | **Stack Seams** — #1149 (harvest, precondition) then #1131 (move + guard), the kind gate (#1153, filed from 1.6.6 roll 3), #1130, #1123, #668, #939, #1022 | #1087 (stack-#1 half), #1112; packaging: #582, #637, #598, #1144, #1151 |
 | **1.7.2** | **Loop Honesty, first half** — #788 (the traceback reaches the repairer), #994, #995, #999, #1110, #968 | **Boundaries** — #154 (the all-packages import guard + four moves), #377, #381, #305, #559, #922, #225, #218 (+ the route-lane test), #219, the identity-permutation test; riders #1148, #1150 |
 | **1.7.3** | **Loop Honesty, second half** — #1054, #1070, with #936/#933 verified-then-closed | **Hardening (infra)** — #1147, #575, #577, #576, #578, #330, #300, #581, #560, #372, #352, #353, #574 |
 | **1.7.4** | **Deferrals** — #820, #376 | **Composition Root** after its design note — #301, #286, #1152 (executor extraction under the goldens); extractions #567, #579; #198, #157, #176, #580 |
 
-**The total: 71 of the 84 open issues fixed across five lines (1.7.0–1.7.4)** — 23
-roll-verified, 48 CI-verified (rev 2 adds #1147–#1152 as CI-verified riders and moves #154
+**The total: 75 of the 88 open issues fixed across five lines (1.7.0–1.7.4)** — 23
+roll-verified, 52 CI-verified (rev 2 adds #1147–#1152 as CI-verified riders and moves #154
 into Boundaries; rev 2 wrote "~68 of 83" and "15 remaining" — counting the table gives 71 and
-13). The remaining 13: four at design review (#414, #557, #1122, #316), six held in the
+13 before rev 3's four Atlas issues, #1157–#1160). The remaining 13: four at design review (#414, #557, #1122, #316), six held in the
 1.8 lane (#950, #949, #194, #80, #1039, #1031), and three verify-then-close (#822, #936,
 #933). The counts per line are the honest ceiling, not a
 target: a line closes when its pack's predictions all hold, and a falsified one costs a
@@ -379,9 +448,9 @@ follows §3's dependencies; a line's rider may move to a neighbour without chang
 
 - **Whether Cross-Cycle Memory's Phase 1 rails ride 1.8 or 2.0** — a 1.8 plan-time decision, as
   the ROADMAP says; 1.7 only leaves the port boundary clean enough that it is an adapter swap.
-- **The Atlas migration date.** Pack Reasoning makes it *possible* (one port, a characterization
-  suite, our own status vocabulary); flipping the provider is its own decision with its own
-  conformance run.
+- **Whether the switch is taken.** Rev 3 places everything up to it (§2.1a) and names the
+  boundary it may land on; the decision itself is the owner's, on #1160's artifact, and this
+  plan records it when it is made rather than forecasting it.
 - **1.6.7.** If the Next.js arm of 1.6.6 closes with a finding that needs a fix before 1.7's
   packs open, it is one more narrow patch on the 1.6 line, and this plan waits for it.
 
@@ -408,8 +477,9 @@ its pack's predictions all hold — and the standing cut procedure in `CLAUDE.md
    read.
 4. Zero code drift between the shakeout deploy and the tag; the release package captured on
    the first try with the `Closes` column correct (#1135 in this rider).
-5. Stated at the cut: what the shakeouts did not exercise, and every remaining pack's
-   placement by name (§3.1) — nothing silently carried.
+5. Stated at the cut: what the shakeouts did not exercise, every remaining pack's placement
+   by name (§3.1), and where Atlas stands — #1157 landed; #1158–#1160 landed or re-placed by
+   name; the switch taken or not, and if taken, the deploy the next line's preflight runs on.
 
 ### 6.2 The line's close — before 1.8 opens
 
@@ -448,4 +518,8 @@ its pack's predictions all hold — and the standing cut procedure in `CLAUDE.md
   1.7.0 (the 1.6 shape: the first pack cut, the slate open), §6 split into the 1.7.0 cut
   (§6.1) and the line's close (§6.2), #1135 moved to 1.7.0's rider, the counts corrected (84 open,
   71 placed in lines, 13 outside), and the residual S/L/B/C/H handles replaced with pack names. Owner's
-  ruling on the two readings, 2026-08-28.
+  ruling on the two readings, 2026-08-28. **Same day, later:** Atlas placed (§2.1a) on the
+  owner's ask to leverage its speed in many cycles — #1157 (P2, required-not-defaulted, the
+  owner's ruling against the SIP's dormant default), #1158, #1159, #1160 filed and placed in
+  1.7.0's rider; the switch as an owner decision at a line boundary; the SIP's revision and
+  acceptance before P4 routed to design review. Correction recorded: Atlas is not vLLM.

--- a/docs/plans/1-7-0-plan.md
+++ b/docs/plans/1-7-0-plan.md
@@ -1,5 +1,16 @@
 # 1.7.0 — plan
 
+**Revision 3, 2026-08-28.** Names the 1.7.0 line. Revision 2 numbered the lines 1.7.1–1.7.5
+and wrote the cut criteria (§6) for a single cut after all of them — the 1.5 shape (one cut,
+34 PRs) — while adopting the 1.6.x cadence, where each line is a tagged release with its own
+cut evidence. The two cannot both hold: v1.7.1 cannot exist before v1.7.0. Rev 3 resolves it
+the 1.6 way — 1.6.0 was cut with the headline landed and the pack open; 1.6.1–1.6.6 followed
+as tagged lines — so **1.7.0 is the Reasoning line**, the one §3 already puts first and alone,
+and the lines renumber 1.7.0–1.7.4. §6 splits into the 1.7.0 cut and the line's close. #1135
+moves to 1.7.0's rider (a rider may move to a neighbour; §6's package-capture criterion
+applies to every cut, so the script fix precedes the first one). The residual letter handles
+(S, L, B, C, H) that survived rev 1's rename are replaced with the pack names.
+
 **Revision 2, 2026-08-27.** Adds the findings of the owner's architectural assessment of
 `main` at `2448f5d1` (read the same evening; every claim acted on was re-verified against the
 tree): six new issues (#1147–#1152), two existing ones sharpened (#154, #301), and three
@@ -16,7 +27,7 @@ harden for 1.8.**
 **1.7 is an odd minor: feature-free by rule.** Its identity is *every port is actually a port* —
 1.5 extracted structure inside the machinery; 1.7 fixes where the machinery meets the outside
 world, so that the Atlas provider migration and 1.8's scorecard grade over seams that hold.
-Substance gates the cut, not the clock; the cut criteria are in §6.
+Substance gates each cut, not the clock; the 1.7.0 cut and the line's close are in §6.
 
 ---
 
@@ -254,7 +265,8 @@ What 1.8's two headliners need under them, taken from the ROADMAP's own gating:
 
 **How we know:** CI is the instrument — the integration job green on main, the images' locked
 deps the ones the suite ran, `pip install squadops` from a clean venv boots the runtime API.
-The cut's release package (step 7) is captured with #1135 fixed, on the first try.
+Each cut's release package (step 7) is captured on the first try — #1135 rides 1.7.0 so the
+first capture already has it.
 
 ### 2.7 Deferrals landing here, and design items routed to review
 
@@ -290,16 +302,17 @@ By dependency and by what each pack proves, never by date:
 3. **Pack Loop Honesty in class-sized PRs**, each with its replay, interleaved with Pack Stack Seams; measured
    together by one FastAPI+React counting set and one Next.js regression arm on a frozen
    deploy — the 1.6.6 protocol, with a prediction per item.
-4. **Pack Boundaries and Pack Composition Root** — B in parallel with 3 (they touch different files); C after its
-   design note is reviewed, and after Pack Reasoning, because the composition root is where the LLM
+4. **Pack Boundaries and Pack Composition Root** — Boundaries in parallel with 3 (they touch
+   different files); Composition Root after its design note is reviewed, and after Pack Reasoning, because the composition root is where the LLM
    factory is wired.
 5. **Pack Hardening continuously**, ops-rider quota per the standing 08-04 rule, with the CI items
    (#1099/#242/#1041/#237) *early* — they are what makes the rest of the release's greens mean
    something.
-6. Verify-then-close, the release-package capture with #1135 fixed, the cut.
+6. Verify-then-close, the release-package capture, the line's close (§6.2). 1.7.0 itself is
+   cut at the end of step 1 (§6.1).
 
 Two lanes as before: executor/handlers/framing surfaces and the loop (Packs Loop Honesty, Stack Seams' fixes, Composition Root) on
-one; adapters, infra, CI, packaging (Pack Reasoning's adapter half, B, H) on the other. Pack Reasoning's port change
+one; adapters, infra, CI, packaging (Pack Reasoning's adapter half, Boundaries, Hardening) on the other. Pack Reasoning's port change
 is the one item both lanes wait on.
 
 ---
@@ -307,7 +320,10 @@ is the one item both lanes wait on.
 ## 3.1 The 1.7.x lines — what fits in one, and the breakdown
 
 A line is one measured pack plus a rider, on the cadence the 1.6.x lines established (a day of
-PRs, an overnight of rolls). The two kinds of fix have two different capacities, because they
+PRs, an overnight of rolls). **1.7.0 is the first line, not the last.** The odd minor opens the
+way 1.6.0 did — the first pack landed and verified, the rest of the slate open and named — and
+closes when §6.2 holds, not when 1.7.0 is tagged; the 1.5 shape (one cut carrying the whole
+slate) is the one the 1.6.x cadence replaced. The two kinds of fix have two different capacities, because they
 are verified differently:
 
 - **Roll-verified items** — anything that changes what a cycle does (loop, scaffold, prompts,
@@ -316,24 +332,25 @@ are verified differently:
   three lines — 1.6.4: 6 items / 8 rolls; 1.6.5: 5 (+#772, #1120) / 12; 1.6.6: 6 / 8 — every
   red attributable to one item or to nothing in the pack. Past ~8, predictions share evidence
   and a red stops naming its cause. **6–8 per line**, measured by one 6+2 set (§4).
-- **CI-verified items** — adapters, ports, vocabulary, infra, packaging, CI itself (Packs Boundaries, C,
-  H). Proven by the suite, a structural guard, or a characterization test; the limit is review
+- **CI-verified items** — adapters, ports, vocabulary, infra, packaging, CI itself (the Boundaries, Composition Root
+  and Hardening packs). Proven by the suite, a structural guard, or a characterization test; the limit is review
   load and merge order. **10–15 per line**, riding beside a measured pack without touching its
   predictions.
 
 | line | measured pack (roll-verified) | CI-verified rider |
 |---|---|---|
-| **1.7.1** | **Reasoning** — #927, #410, #924 (budget half), #1145, #930 — first and alone, because it changes what every later token number means | #901, #929, #944; the CI-truth items first: #1099, #242, #1041, #237 |
-| **1.7.2** | **Stack Seams** — #1149 (harvest, precondition) then #1131 (move + guard), the kind gate (#1153, filed from 1.6.6 roll 3), #1130, #1123, #668, #939, #1022 | #1087 (stack-#1 half), #1112; packaging: #582, #637, #598, #1135, #1144, #1151 |
-| **1.7.3** | **Loop Honesty, first half** — #788 (the traceback reaches the repairer), #994, #995, #999, #1110, #968 | **Boundaries** — #154 (the all-packages import guard + four moves), #377, #381, #305, #559, #922, #225, #218 (+ the route-lane test), #219, the identity-permutation test; riders #1148, #1150 |
-| **1.7.4** | **Loop Honesty, second half** — #1054, #1070, with #936/#933 verified-then-closed | **Hardening (infra)** — #1147, #575, #577, #576, #578, #330, #300, #581, #560, #372, #352, #353, #574 |
-| **1.7.5** | **Deferrals** — #820, #376 | **Composition Root** after its design note — #301, #286, #1152 (executor extraction under the goldens); extractions #567, #579; #198, #157, #176, #580 |
+| **1.7.0** | **Reasoning** — #927, #410, #924 (budget half), #1145, #930 — first and alone, because it changes what every later token number means | #901, #929, #944; the CI-truth items first: #1099, #242, #1041, #237; #1135 (the package capture credits `Closes` in code spans — fixed before the first capture) |
+| **1.7.1** | **Stack Seams** — #1149 (harvest, precondition) then #1131 (move + guard), the kind gate (#1153, filed from 1.6.6 roll 3), #1130, #1123, #668, #939, #1022 | #1087 (stack-#1 half), #1112; packaging: #582, #637, #598, #1144, #1151 |
+| **1.7.2** | **Loop Honesty, first half** — #788 (the traceback reaches the repairer), #994, #995, #999, #1110, #968 | **Boundaries** — #154 (the all-packages import guard + four moves), #377, #381, #305, #559, #922, #225, #218 (+ the route-lane test), #219, the identity-permutation test; riders #1148, #1150 |
+| **1.7.3** | **Loop Honesty, second half** — #1054, #1070, with #936/#933 verified-then-closed | **Hardening (infra)** — #1147, #575, #577, #576, #578, #330, #300, #581, #560, #372, #352, #353, #574 |
+| **1.7.4** | **Deferrals** — #820, #376 | **Composition Root** after its design note — #301, #286, #1152 (executor extraction under the goldens); extractions #567, #579; #198, #157, #176, #580 |
 
-**The total: ~68 of the 83 open issues fixed across five lines** — 23 roll-verified, ~45
-CI-verified (rev 2 adds #1147–#1152 as CI-verified riders and moves #154 into Boundaries).
-The remaining 15: four at design review (#414, #557, #1122, #316), six held in the
-1.8 lane (#950, #949, #194, #80, #1039, #1031), and five verify-then-close or folded (#822,
-#936, #933 and the two the packs absorb). The counts per line are the honest ceiling, not a
+**The total: 71 of the 84 open issues fixed across five lines (1.7.0–1.7.4)** — 23
+roll-verified, 48 CI-verified (rev 2 adds #1147–#1152 as CI-verified riders and moves #154
+into Boundaries; rev 2 wrote "~68 of 83" and "15 remaining" — counting the table gives 71 and
+13). The remaining 13: four at design review (#414, #557, #1122, #316), six held in the
+1.8 lane (#950, #949, #194, #80, #1039, #1031), and three verify-then-close (#822, #936,
+#933). The counts per line are the honest ceiling, not a
 target: a line closes when its pack's predictions all hold, and a falsified one costs a
 1.7.x.1 before the next pack opens — the same rule the 1.6.x lines ran under. The line order
 follows §3's dependencies; a line's rider may move to a neighbour without changing the packs.
@@ -344,7 +361,7 @@ follows §3's dependencies; a line's rider may move to a neighbour without chang
 
 1.7 has no headline feature to measure, so it measures its own claim: *the seams hold*.
 
-- **Two counting sets on one frozen deploy after Packs Reasoning, S and L land** — FastAPI+React N=6,
+- **Two counting sets on one frozen deploy after the Reasoning, Stack Seams and Loop Honesty packs land** — FastAPI+React N=6,
   Next.js+TS N=2 (the 1.6.6 sizing, for the same reasons), pre-registered with one falsifiable
   prediction per landed item: the reasoning level resolves per capability (read from LangFuse);
   no green suite is failed by a stack-shaped check; a kind-contradicting assertion is rejected at
@@ -354,7 +371,7 @@ follows §3's dependencies; a line's rider may move to a neighbour without chang
   intervals and no bar; greens by repair vs by re-dispatch; qa primary completion tokens against
   1.6.6's `3233–6594` — the distribution Pack Reasoning is expected to move down, reported as measured.
 - **CI as the second instrument**: the integration job, the adapter characterization suite,
-  the structural guards — all green on the cut commit, and the cut says so.
+  the structural guards — all green on each cut commit, and the cut says so.
 
 ---
 
@@ -372,10 +389,33 @@ follows §3's dependencies; a line's rider may move to a neighbour without chang
 
 ## 6. Cut criteria
 
-Substance, not the clock:
+Substance, not the clock. Two cuts are gated here: the one that opens the line and the one
+that closes it. The 1.7.1–1.7.4 cuts between them run under §3.1's rule — a line closes when
+its pack's predictions all hold — and the standing cut procedure in `CLAUDE.md`.
 
-1. Packs Reasoning, S, B and C fully landed; Pack Loop Honesty and Pack Hardening at the ops-rider quota with every
-   remaining item re-placed by name (nothing silently carried).
+### 6.1 The 1.7.0 cut — the Reasoning line
+
+1. Pack Reasoning fully landed: #927 (the level on the port, the contract declaring it, the
+   Ollama mapping), #410 (the thinking channel captured and emitted), #1145, #930; #924's
+   budget half re-read against the new distribution and recorded either way.
+2. Pack Reasoning's verification story held (§2.1): the #924 probe replayed through the port
+   with the `none`/`high` split reproduced from our own telemetry and thinking text present
+   in LangFuse on the `high` run; one shakeout per stack with fills-first (Q0) holding; the
+   adapter characterization suite green in CI against the recorded transcript.
+3. The rider landed: #901, #929, #944 (the dead `LLMRouter` gone, the call sequence extracted),
+   and the CI-truth items #1099, #242, #1041, #237 — so the integration job is green on main
+   and CI runs the dependency set the images install, *before* any later line's greens are
+   read.
+4. Zero code drift between the shakeout deploy and the tag; the release package captured on
+   the first try with the `Closes` column correct (#1135 in this rider).
+5. Stated at the cut: what the shakeouts did not exercise, and every remaining pack's
+   placement by name (§3.1) — nothing silently carried.
+
+### 6.2 The line's close — before 1.8 opens
+
+1. The Reasoning, Stack Seams, Boundaries and Composition Root packs fully landed; Loop
+   Honesty and Hardening at the ops-rider quota with every remaining item re-placed by name
+   (nothing silently carried).
 2. Both counting sets closed with no falsified prediction; the record written from per-round
    evidence.
 3. CI green on main including the integration job, on Python 3.12, against the locked deps the
@@ -403,3 +443,9 @@ Substance, not the clock:
   effort); #218 carries a route-lane test; an identity-permutation test added to Boundaries with
   no issue behind it. Not adopted: the assessment's note of a hardcoded agent-name→role map in
   the entrypoint (checked — it is gone), and #194 / #1122 stay where rev 1 put them.
+- **Rev 3 (2026-08-28)** — the 1.7.0 line named. Rev 2's §3.1 numbered the lines 1.7.1–1.7.5
+  and §6 gated one cut after all of them; the lines renumber 1.7.0–1.7.4 with Reasoning as
+  1.7.0 (the 1.6 shape: the first pack cut, the slate open), §6 split into the 1.7.0 cut
+  (§6.1) and the line's close (§6.2), #1135 moved to 1.7.0's rider, the counts corrected (84 open,
+  71 placed in lines, 13 outside), and the residual S/L/B/C/H handles replaced with pack names. Owner's
+  ruling on the two readings, 2026-08-28.


### PR DESCRIPTION
## What

`docs/plans/1-7-0-plan.md` rev 3, two commits.

**Commit 1 — name the 1.7.0 line.** Rev 2's §3.1 numbered the 1.7.x lines **1.7.1–1.7.5** and wrote §6 as a single cut after all five — the 1.5 shape (one cut, 34 PRs) — while explicitly adopting the 1.6.x cadence, where each line is a tagged release with its own cut evidence. Those cannot both hold: v1.7.1 cannot exist before v1.7.0. Resolved the 1.6 way (1.6.0 cut with the headline landed and the pack open; 1.6.1–1.6.6 followed as tagged lines):

- **1.7.0 = the Reasoning line** — the pack §3 already puts "first and alone" (#927, #410, #924 budget half, #1145, #930) plus its rider. Lines renumber **1.7.0–1.7.4**.
- **§6 split**: §6.1 the 1.7.0 cut (the Reasoning pack's own verification story); §6.2 the line's close before 1.8 opens (rev 2's §6 text).
- **#1135 moves to 1.7.0's rider** — the package-capture criterion applies to every cut, so the script fix precedes the first one.
- **Residual letter handles** (S, L, B, C, H) replaced with the pack names rev 1 introduced.

**Commit 2 — place Atlas (§2.1a), on the owner's ask to leverage its speed for wall-clock savings across many cycles.** The proposed SIP-Atlas-Provider-Adapter scheduled the cutover for "1.8+"; its own Ruling 1 waives placement and Ruling 2 makes the switch a config change on observed results. Rev 3 orders it inside 1.7.0's rider:

- **#1157** — provider selection, **required not defaulted** (the owner's ruling against the SIP's §3.1/§4.1 dormant default, whose 1.6-window rationale expired at v1.6.6). The factory defaults `ollama`, the entrypoint never passes a provider, `LLMConfig` has no field — the vLLM adapter has been unreachable since it landed.
- **#1158** — Atlas serving on the Spark (bootstrap-installed on `local-spark`, container-reachable, the SIP's live-verification facts answered in writing, plus a new fact 6: what reasoning control Atlas honors). Starts now; no code dependency.
- **#1159** — the adapter, after #927's port change so it implements the reasoning level from the start.
- **#1160** — the §3.6.1 A/B artifact, `wall_clock_ms` as the decision field, one full cycle per arm.
- **The switch** is an owner decision on #1160's artifact, one PR changing the value every deploy surface carries, at a **line boundary, never mid-set** — earliest the 1.7.0 cut, so 1.7.1's counting set is the first on Atlas.
- The SIP's revision and acceptance before P4 is routed to design review (P0–P6 were implemented against it while `proposed`).
- §2.1 also records: the reasoning dial kind is a model-spec fact (per model family, not per provider); the characterization suite records every adapter in the tree. Correction: Atlas is not vLLM (SIP §2.0).

**Counts corrected from the table**: 88 open, 75 placed in lines (23 roll-verified, 52 CI-verified), 13 outside. Every open issue at `0e477ecd` + #1157–#1160 is named in the plan.

## Closes

No issue: plan revision; the numbering gap was found reading the plan against the 1.5/1.6 CHANGELOG entries, and the Atlas placement is the owner's ask of 2026-08-28 — the work items it names are #1157–#1160.

## Evidence

Docs only. `gh issue list --state open` cross-checked against every `#N` the plan places: 88 open, 88 placed, none missing. No code, no version markers touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbzZWzB8VgjZdbtKX9N41L
