### PR TITLE
feat(llm): reasoning is a level on the port, declared per capability, mapped by each adapter (#927, 1.7.0 Reasoning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to SquadOps are recorded here. Format loosely follows
   with no channel). `LLMCapability.REASONING_CONTROL` declares whether a level
   reaches the wire, and the conformance suite asserts the declaration against the
   request bodies for every adapter. No level sent ⇒ the wire is byte-identical to
-  1.6.6.
+  what it was before this change.
 - **Every capability declares how much reasoning its output wants**
   (`capabilities/reasoning_policy.py`): a transcription — filling scaffold slots,
   a repair verdict, a stored report — is `none`; an argument — the manifest, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,32 @@ All notable changes to SquadOps are recorded here. Format loosely follows
 
 ## [Unreleased]
 
-Nothing yet.
+**1.7.0 — the Reasoning line opens.** Plan: `docs/plans/1-7-0-plan.md` (rev 3).
+
+### Added — reasoning is a level on the port (#927)
+- **The port carries `reasoning: none | low | medium | high`**, never a provider's
+  switch. Ollama maps `none → think:false` and any graded level → `think:true`; vLLM
+  maps by the dial the model spec declares (`chat_template_kwargs.enable_thinking`
+  for a toggle model, `reasoning_effort` for an effort model, nothing for a model
+  with no channel). `LLMCapability.REASONING_CONTROL` declares whether a level
+  reaches the wire, and the conformance suite asserts the declaration against the
+  request bodies for every adapter. No level sent ⇒ the wire is byte-identical to
+  1.6.6.
+- **Every capability declares how much reasoning its output wants**
+  (`capabilities/reasoning_policy.py`): a transcription — filling scaffold slots,
+  a repair verdict, a stored report — is `none`; an argument — the manifest, the
+  analyses, the plan — is `high`. #924 measured the difference on the deployed qa
+  fill brief: 5,727 completion tokens with the channel on, 413 with it off, the same
+  eight fences. No default: an undeclared capability raises, and a test over the
+  handler registry makes the gap a CI failure.
+- **Resolution is the chain every other knob uses**: the declaration →
+  `config_overrides.reasoning` (a new allowed key, value validated at the profile
+  boundary) → the model's dial (`ModelSpec.reasoning_control`, required on every
+  registry entry; qwen3.x `toggle`, qwen2.5/llama3 `none` — a model with no channel
+  gets no level, since Ollama rejects `think` for it).
+- **`GenerationRecord.reasoning`** carries the sent level to LangFuse, so "how
+  much did this call think" is read per generation rather than inferred from a
+  token count.
 
 ## [1.6.6] — 2026-08-28
 

--- a/adapters/llm/ollama.py
+++ b/adapters/llm/ollama.py
@@ -18,7 +18,7 @@ from squadops.llm.exceptions import (
     LLMModelNotFoundError,
     LLMTimeoutError,
 )
-from squadops.llm.models import ChatMessage, LLMRequest, LLMResponse, ModelInfo
+from squadops.llm.models import ChatMessage, LLMRequest, LLMResponse, ModelInfo, ReasoningLevel
 from squadops.ports.llm.provider import LLMCapability, LLMPort
 
 logger = logging.getLogger(__name__)
@@ -80,16 +80,20 @@ class OllamaAdapter(LLMPort):
 
         ``thinking_tokens`` is False deliberately, and it is not a statement
         about the models: qwen3-family models emit ``message.thinking`` through
-        Ollama by default, but this adapter never sends a ``think`` parameter and
-        reads only ``message.content``. Reasoning tokens are paid for and cannot
-        be separated from content here (#410). Declaring True would tell a caller
-        it could split them.
+        Ollama by default, and this adapter reads only ``message.content``.
+        Reasoning tokens are paid for and cannot be separated from content here
+        (#410). Declaring True would tell a caller it could split them.
+
+        ``reasoning_control`` is True: a level maps onto the ``think`` flag
+        (#927), so the channel can at least be switched off where the output is
+        a transcription — the 13.9× token difference #924 measured.
         """
         return {
             LLMCapability.MODEL_LISTING: True,
             LLMCapability.MODEL_MANAGEMENT: True,
             LLMCapability.STREAMING_USAGE: True,
             LLMCapability.THINKING_TOKENS: False,
+            LLMCapability.REASONING_CONTROL: True,
         }
 
     async def _get_client(self) -> httpx.AsyncClient:
@@ -126,6 +130,8 @@ class OllamaAdapter(LLMPort):
 
         if request.format == "json":
             payload["format"] = "json"
+        if request.reasoning is not None:
+            payload["think"] = request.reasoning != ReasoningLevel.NONE
 
         try:
             response = await client.post(
@@ -175,10 +181,19 @@ class OllamaAdapter(LLMPort):
         model: str,
         max_tokens: int | None,
         temperature: float | None,
+        reasoning: str | None = None,
         *,
         stream: bool = False,
     ) -> dict[str, Any]:
-        """Build the Ollama /api/chat request payload."""
+        """Build the Ollama /api/chat request payload.
+
+        ``reasoning`` maps onto Ollama's ``think`` flag — the only dial the
+        dialect has, so the port's graded levels collapse to on/off here:
+        ``none`` → ``think: false``, any other level → ``think: true``. ``None``
+        sends no ``think`` at all and the payload is byte-identical to the
+        pre-#927 one; the caller is expected not to pass a level for a model
+        with no reasoning channel, since Ollama rejects ``think`` for those.
+        """
         payload: dict[str, Any] = {
             "model": model,
             "messages": [{"role": m.role, "content": m.content} for m in messages],
@@ -192,6 +207,8 @@ class OllamaAdapter(LLMPort):
             options["temperature"] = temperature
         if options:
             payload["options"] = options
+        if reasoning is not None:
+            payload["think"] = reasoning != ReasoningLevel.NONE
 
         return payload
 
@@ -202,6 +219,7 @@ class OllamaAdapter(LLMPort):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        reasoning: str | None = None,
     ) -> ChatMessage:
         """Chat with the LLM using message history.
 
@@ -223,6 +241,7 @@ class OllamaAdapter(LLMPort):
             resolved_model,
             max_tokens,
             temperature,
+            reasoning,
             stream=False,
         )
 
@@ -275,6 +294,7 @@ class OllamaAdapter(LLMPort):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        reasoning: str | None = None,
     ) -> ChatMessage:
         """Stream chat internally for connection liveness, return complete ChatMessage with usage.
 
@@ -290,6 +310,7 @@ class OllamaAdapter(LLMPort):
             resolved_model,
             max_tokens,
             temperature,
+            reasoning,
             stream=True,
         )
 
@@ -367,6 +388,7 @@ class OllamaAdapter(LLMPort):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        reasoning: str | None = None,
     ) -> AsyncIterator[str]:
         """Stream chat response as plain text chunks.
 
@@ -381,6 +403,7 @@ class OllamaAdapter(LLMPort):
             resolved_model,
             max_tokens,
             temperature,
+            reasoning,
             stream=True,
         )
 

--- a/adapters/llm/ollama.py
+++ b/adapters/llm/ollama.py
@@ -192,7 +192,8 @@ class OllamaAdapter(LLMPort):
         ``none`` → ``think: false``, any other level → ``think: true``. ``None``
         sends no ``think`` at all and the payload is byte-identical to the
         pre-#927 one; the caller is expected not to pass a level for a model
-        with no reasoning channel, since Ollama rejects ``think`` for those.
+        with no reasoning channel, since Ollama rejects ``think: true`` for those (400, "does not support
+        thinking" — measured 2026-08-28 on 0.32.14).
         """
         payload: dict[str, Any] = {
             "model": model,

--- a/adapters/llm/vllm.py
+++ b/adapters/llm/vllm.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 
 import httpx
@@ -44,7 +44,8 @@ from squadops.llm.exceptions import (
     LLMModelNotFoundError,
     LLMTimeoutError,
 )
-from squadops.llm.models import ChatMessage, LLMRequest, LLMResponse, ModelInfo
+from squadops.llm.model_registry import ModelSpec, ReasoningControl, get_model_spec
+from squadops.llm.models import ChatMessage, LLMRequest, LLMResponse, ModelInfo, ReasoningLevel
 from squadops.ports.llm.provider import LLMCapability, LLMPort
 
 logger = logging.getLogger(__name__)
@@ -66,6 +67,37 @@ def _tokens_per_second(completion_tokens: int | None, elapsed_seconds: float) ->
     if not completion_tokens or elapsed_seconds <= 0:
         return None
     return round(completion_tokens / elapsed_seconds, 2)
+
+
+# The port's level → the request fields for each reasoning dial a model can
+# declare (#927). The OpenAI request shape has no reasoning field of its own;
+# every model family reaches its channel differently, so the mapping is keyed on
+# the dial the model spec declares, never on the model's name.
+_REASONING_DIALS: dict[str, Callable[[str], dict[str, Any]]] = {
+    # qwen3-family: a chat-template switch. The grades collapse to on.
+    ReasoningControl.TOGGLE: lambda level: {
+        "chat_template_kwargs": {"enable_thinking": level != ReasoningLevel.NONE}
+    },
+    # gpt-oss-family: the level verbatim. ``none`` cannot be expressed on this
+    # dial — the model always reasons — so it becomes the lowest effort.
+    ReasoningControl.EFFORT: lambda level: {
+        "reasoning_effort": ReasoningLevel.LOW if level == ReasoningLevel.NONE else level
+    },
+}
+
+
+def _reasoning_fields(spec: ModelSpec | None, reasoning: str) -> dict[str, Any]:
+    """Request fields expressing ``reasoning`` on the dial ``spec`` declares.
+
+    Empty for a model with no dial or no registry entry: a field the server does
+    not understand is rejected outright by some backends, and the port states
+    the level is a request, not a guarantee. (An unregistered model is #1145's
+    preflight finding, not this adapter's guess.)
+    """
+    if spec is None:
+        return {}
+    dial = _REASONING_DIALS.get(spec.reasoning_control)
+    return dial(reasoning) if dial else {}
 
 
 def _usage_from(payload: dict[str, Any]) -> tuple[int | None, int | None, int | None]:
@@ -148,6 +180,10 @@ class VLLMAdapter(LLMPort):
             LLMCapability.MODEL_MANAGEMENT: False,
             LLMCapability.STREAMING_USAGE: True,
             LLMCapability.THINKING_TOKENS: False,
+            # A level reaches the wire only on the dial the model spec declares
+            # (``_REASONING_DIALS``); for a model with none it is dropped, which is
+            # the port's stated contract, not a capability outage.
+            LLMCapability.REASONING_CONTROL: True,
         }
 
     async def _get_client(self) -> httpx.AsyncClient:
@@ -166,6 +202,7 @@ class VLLMAdapter(LLMPort):
         model: str,
         max_tokens: int | None,
         temperature: float | None,
+        reasoning: str | None = None,
         *,
         stream: bool = False,
     ) -> dict[str, Any]:
@@ -178,6 +215,8 @@ class VLLMAdapter(LLMPort):
             payload["max_tokens"] = max_tokens
         if temperature is not None:
             payload["temperature"] = temperature
+        if reasoning is not None:
+            payload.update(_reasoning_fields(get_model_spec(model), reasoning))
         if stream:
             # Without this the stream carries no usage frame at all and token
             # accounting for streamed calls is simply lost.
@@ -216,6 +255,7 @@ class VLLMAdapter(LLMPort):
             max_tokens=request.max_tokens,
             temperature=request.temperature,
             timeout_seconds=request.timeout_seconds,
+            reasoning=request.reasoning,
             operation="generate",
         )
         return LLMResponse(
@@ -234,6 +274,7 @@ class VLLMAdapter(LLMPort):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        reasoning: str | None = None,
     ) -> ChatMessage:
         return await self._chat(
             messages,
@@ -241,6 +282,7 @@ class VLLMAdapter(LLMPort):
             max_tokens=max_tokens,
             temperature=temperature,
             timeout_seconds=timeout_seconds,
+            reasoning=reasoning,
             operation="chat",
         )
 
@@ -252,6 +294,7 @@ class VLLMAdapter(LLMPort):
         max_tokens: int | None,
         temperature: float | None,
         timeout_seconds: float | None,
+        reasoning: str | None,
         operation: str,
     ) -> ChatMessage:
         client = await self._get_client()
@@ -261,7 +304,7 @@ class VLLMAdapter(LLMPort):
         try:
             response = await client.post(
                 "/v1/chat/completions",
-                json=self._payload(messages, model, max_tokens, temperature),
+                json=self._payload(messages, model, max_tokens, temperature, reasoning),
                 timeout=timeout,
             )
             response.raise_for_status()
@@ -300,6 +343,7 @@ class VLLMAdapter(LLMPort):
         max_tokens: int | None,
         temperature: float | None,
         timeout: float,
+        reasoning: str | None,
         operation: str,
     ) -> AsyncIterator[dict[str, Any]]:
         """Yield decoded SSE frames, skipping the terminal sentinel.
@@ -313,7 +357,9 @@ class VLLMAdapter(LLMPort):
             async with client.stream(
                 "POST",
                 "/v1/chat/completions",
-                json=self._payload(messages, model, max_tokens, temperature, stream=True),
+                json=self._payload(
+                    messages, model, max_tokens, temperature, reasoning, stream=True
+                ),
                 timeout=timeout,
             ) as response:
                 response.raise_for_status()
@@ -337,6 +383,7 @@ class VLLMAdapter(LLMPort):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        reasoning: str | None = None,
     ) -> AsyncIterator[str]:
         """Stream assistant content as plain text chunks."""
         resolved = model or self._default_model
@@ -346,6 +393,7 @@ class VLLMAdapter(LLMPort):
             max_tokens,
             temperature,
             timeout_seconds or self._timeout,
+            reasoning,
             "chat_stream",
         ):
             for choice in frame.get("choices") or []:
@@ -360,6 +408,7 @@ class VLLMAdapter(LLMPort):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        reasoning: str | None = None,
     ) -> ChatMessage:
         """Stream for connection liveness, return one assembled message.
 
@@ -378,6 +427,7 @@ class VLLMAdapter(LLMPort):
             max_tokens,
             temperature,
             timeout_seconds or self._timeout,
+            reasoning,
             "chat_stream_with_usage",
         ):
             if frame.get("usage"):

--- a/adapters/noop/ports.py
+++ b/adapters/noop/ports.py
@@ -50,6 +50,7 @@ class NoOpLLMPort(LLMPort):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        reasoning: str | None = None,
     ) -> ChatMessage:
         raise NotImplementedError("NoOpLLMPort: no LLM provider configured")
 
@@ -60,6 +61,7 @@ class NoOpLLMPort(LLMPort):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        reasoning: str | None = None,
     ) -> AsyncIterator[str]:
         raise NotImplementedError("NoOpLLMPort: no LLM provider configured")
         yield  # pragma: no cover — unreachable, makes this a proper async generator

--- a/adapters/telemetry/langfuse/adapter.py
+++ b/adapters/telemetry/langfuse/adapter.py
@@ -431,6 +431,7 @@ class LangFuseAdapter(LLMObservabilityPort):
                 "metadata": {
                     "latency_ms": record.latency_ms,
                     "tokens_per_second": record.tokens_per_second,
+                    "reasoning": record.reasoning,
                     "prompt_layer_set_id": prompt_layers.prompt_layer_set_id,
                     "prompt_layers": [
                         {

--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -15,6 +15,7 @@ from squadops.capabilities.handlers.base import (
     HandlerEvidence,
     HandlerResult,
 )
+from squadops.capabilities.reasoning_policy import resolve_reasoning_level
 from squadops.cycles.acceptance_check_spec import (
     CHECK_SPECS,
     CONFIG_OFF_SKIP_REASONS,
@@ -378,6 +379,13 @@ class _CycleTaskHandler(CapabilityHandler):
             kwargs["max_tokens"] = spec.default_max_completion
         if "timeout_seconds" in overrides:
             kwargs["timeout_seconds"] = overrides["timeout_seconds"]
+        # #927: keyed on the agent's model exactly as the completion clamp is — a
+        # task dispatched without one sends no level, as it gets no clamp.
+        reasoning = resolve_reasoning_level(
+            self._capability_id, agent_overrides=overrides, model_name=agent_model
+        )
+        if reasoning is not None:
+            kwargs["reasoning"] = reasoning
         return kwargs
 
     # SIP-0086: Output validation and self-evaluation (Stage B)
@@ -734,6 +742,7 @@ class _CycleTaskHandler(CapabilityHandler):
                     if rendered and rendered.template_version
                     else None
                 ),
+                reasoning=chat_kwargs.get("reasoning"),
             )
             if response.tokens_per_second:
                 logger.info(
@@ -864,6 +873,7 @@ class _CycleTaskHandler(CapabilityHandler):
         resolved_model: str | None = None,
         rendered: object | None = None,
         chat_response: ChatMessage | None = None,
+        reasoning: str | None = None,
     ) -> None:
         """Record LLM generation for LangFuse tracing (SIP-0061).
 
@@ -908,6 +918,7 @@ class _CycleTaskHandler(CapabilityHandler):
                     if rendered and getattr(rendered, "template_version", None)
                     else None
                 ),
+                reasoning=reasoning,
             )
             layers = PromptLayerMetadata(
                 prompt_layer_set_id=f"{self._role}-{self._prompt_layer_kind}",

--- a/src/squadops/capabilities/handlers/cycle/builder.py
+++ b/src/squadops/capabilities/handlers/cycle/builder.py
@@ -23,6 +23,7 @@ from squadops.capabilities.handlers.cycle.validation import (
     _classify_file,
 )
 from squadops.capabilities.handlers.emission_log import log_emission_shape
+from squadops.capabilities.reasoning_policy import reasoning_kwargs, resolve_reasoning_level
 
 logger = logging.getLogger(__name__)
 
@@ -428,6 +429,12 @@ class BuilderAssembleHandler(_CycleTaskHandler):
             builder_kwargs["model"] = agent_model
         if "temperature" in agent_overrides:
             builder_kwargs["temperature"] = agent_overrides["temperature"]
+        reasoning = resolve_reasoning_level(
+            self._capability_id,
+            agent_overrides=agent_overrides,
+            model_name=agent_model or context.ports.llm.default_model,
+        )
+        builder_kwargs.update(reasoning_kwargs(reasoning))
 
         try:
             response = await context.ports.llm.chat_stream_with_usage(messages, **builder_kwargs)
@@ -449,6 +456,7 @@ class BuilderAssembleHandler(_CycleTaskHandler):
             resolved_model,
             rendered=rendered,
             chat_response=response,
+            reasoning=reasoning,
         )
 
         # Step 5: Parse fenced code blocks

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -32,6 +32,7 @@ from squadops.capabilities.handlers.cycle.validation import (
     _estimate_min_artifacts,
 )
 from squadops.capabilities.handlers.emission_log import log_emission_shape
+from squadops.capabilities.reasoning_policy import reasoning_kwargs, resolve_reasoning_level
 
 logger = logging.getLogger(__name__)
 
@@ -497,6 +498,10 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
             chat_kwargs["model"] = agent_model
         if "temperature" in agent_overrides:
             chat_kwargs["temperature"] = agent_overrides["temperature"]
+        reasoning = resolve_reasoning_level(
+            self._capability_id, agent_overrides=agent_overrides, model_name=model_name
+        )
+        chat_kwargs.update(reasoning_kwargs(reasoning))
 
         messages = [
             ChatMessage(role="system", content=system_prompt),
@@ -522,6 +527,7 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
             model_name,
             rendered=rendered,
             chat_response=response,
+            reasoning=reasoning,
         )
 
         # Parse fenced code blocks

--- a/src/squadops/capabilities/handlers/cycle/governance.py
+++ b/src/squadops/capabilities/handlers/cycle/governance.py
@@ -179,6 +179,7 @@ class GovernanceReviewHandler(_CycleTaskHandler):
             chat_kwargs.get("model") or context.ports.llm.default_model,
             rendered=rendered,
             chat_response=response,
+            reasoning=chat_kwargs.get("reasoning"),
         )
 
         prd_summary = str(prd)[:80] if prd else "(no PRD)"

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -48,6 +48,7 @@ from squadops.capabilities.handlers.cycle.validation import (
     _is_test_file,
 )
 from squadops.capabilities.handlers.emission_log import log_emission_shape
+from squadops.capabilities.reasoning_policy import reasoning_kwargs, resolve_reasoning_level
 
 logger = logging.getLogger(__name__)
 
@@ -1080,6 +1081,10 @@ class QATestHandler(_CycleTaskHandler):
             chat_kwargs["model"] = agent_model
         if "temperature" in agent_overrides:
             chat_kwargs["temperature"] = agent_overrides["temperature"]
+        reasoning = resolve_reasoning_level(
+            self._capability_id, agent_overrides=agent_overrides, model_name=model_name
+        )
+        chat_kwargs.update(reasoning_kwargs(reasoning))
 
         messages = [
             ChatMessage(role="system", content=system_prompt),
@@ -1103,6 +1108,7 @@ class QATestHandler(_CycleTaskHandler):
             model_name,
             rendered=rendered,
             chat_response=response,
+            reasoning=reasoning,
         )
 
         scaffold_input = inputs.get("verification_scaffold")

--- a/src/squadops/capabilities/handlers/planning/base.py
+++ b/src/squadops/capabilities/handlers/planning/base.py
@@ -299,6 +299,7 @@ class _PlanningTaskHandler(_CycleTaskHandler):
                     if rendered and rendered.template_version
                     else None
                 ),
+                reasoning=chat_kwargs.get("reasoning"),
             )
             layers = PromptLayerMetadata(
                 prompt_layer_set_id=f"{self._role}-planning",

--- a/src/squadops/capabilities/reasoning_policy.py
+++ b/src/squadops/capabilities/reasoning_policy.py
@@ -23,7 +23,7 @@ in the package has an entry, so the gap is a CI failure, not a cycle finding.
 Resolution is the chain every other generation knob already uses (SIP-0075 §3.2,
 #1011): the capability's declaration, then the agent's ``config_overrides``, then
 the model spec's clamp — a model with no reasoning channel gets no level at all,
-because Ollama rejects ``think`` for such a model and the port says a level is a
+because Ollama answers ``think: true`` for such a model with a 400 and the port says a level is a
 request. A cycle-level (CRP) override is not wired here; the CRP applied-defaults
 carry no per-agent LLM knobs today, and adding one is a contract-pack change.
 """

--- a/src/squadops/capabilities/reasoning_policy.py
+++ b/src/squadops/capabilities/reasoning_policy.py
@@ -1,0 +1,132 @@
+"""How much reasoning each capability wants — declared once, resolved one way (#927).
+
+**Reason where the output is an argument. Don't where the output is a transcription.**
+
+Filling scaffold slots is derivation: shells, contract and envelope are all in the
+prompt and the answer is a fixed format. Authoring an interface manifest from
+behavioural prose is genuinely an argument: endpoints, statuses and error semantics
+are being chosen, not restated. #924 measured the difference on the deployed qa
+fill brief — 5,727 completion tokens with the channel on, 413 with it off, the
+same eight fill fences — and the loop had been treating that as a budget problem.
+
+The table is the capability's declaration. It lives here rather than on each
+handler because the fact is *about the output shape*, not about the class that
+produces it, and because a table can be read whole: every capability, one level,
+no switch named for a mitigation (the #925 shape). When #922 gives cycle
+capabilities a contract as data, the column moves there.
+
+**No default.** A capability absent from the table raises: an undeclared level
+would silently leave the channel on, which is the condition this module exists
+to end. ``tests/unit/capabilities/test_reasoning_policy.py`` asserts every handler
+in the package has an entry, so the gap is a CI failure, not a cycle finding.
+
+Resolution is the chain every other generation knob already uses (SIP-0075 §3.2,
+#1011): the capability's declaration, then the agent's ``config_overrides``, then
+the model spec's clamp — a model with no reasoning channel gets no level at all,
+because Ollama rejects ``think`` for such a model and the port says a level is a
+request. A cycle-level (CRP) override is not wired here; the CRP applied-defaults
+carry no per-agent LLM knobs today, and adding one is a contract-pack change.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from squadops.llm.model_registry import ReasoningControl, get_model_spec
+from squadops.llm.models import ReasoningLevel
+
+#: Per capability: the level its output wants. Grouped by the judgment behind it.
+REASONING_BY_CAPABILITY: dict[str, str] = {
+    # --- transcription: the prompt determines the output; the model restates it ---
+    "qa.test": ReasoningLevel.NONE,  # fills scaffold slots (#924's measured case)
+    "qa.test_repair": ReasoningLevel.NONE,
+    "builder.assemble": ReasoningLevel.NONE,
+    "builder.assemble_repair": ReasoningLevel.NONE,
+    "governance.correction_decision": ReasoningLevel.NONE,  # a verdict from evidence
+    "qa.validate": ReasoningLevel.NONE,
+    "qa.assess_outcomes": ReasoningLevel.NONE,
+    "data.report": ReasoningLevel.NONE,
+    "data.gather_evidence": ReasoningLevel.NONE,
+    "data.analyze_verification": ReasoningLevel.NONE,
+    "data.classify_unresolved": ReasoningLevel.NONE,
+    "data.collect_cycle_snapshot": ReasoningLevel.NONE,
+    "data.compose_cycle_summary": ReasoningLevel.NONE,
+    "data.profile_cycle_metrics": ReasoningLevel.NONE,
+    "governance.publish_handoff": ReasoningLevel.NONE,  # a stored report
+    # --- implementation and revision: derivation with real choices inside it ---
+    "development.develop": ReasoningLevel.MEDIUM,
+    "development.repair": ReasoningLevel.MEDIUM,
+    "development.correction_repair": ReasoningLevel.MEDIUM,
+    "governance.incorporate_feedback": ReasoningLevel.MEDIUM,
+    "qa.validate_refinement": ReasoningLevel.MEDIUM,
+    "data.research_context": ReasoningLevel.MEDIUM,
+    # --- argument: the output chooses; the design, the analysis, the plan ---
+    "development.author_manifest": ReasoningLevel.HIGH,
+    "strategy.analyze_prd": ReasoningLevel.HIGH,
+    "strategy.frame_objective": ReasoningLevel.HIGH,
+    "development.design": ReasoningLevel.HIGH,
+    "development.design_plan": ReasoningLevel.HIGH,
+    "qa.define_test_strategy": ReasoningLevel.HIGH,
+    "governance.prepare_plan_authoring_brief": ReasoningLevel.HIGH,
+    "development.propose_plan_tasks": ReasoningLevel.HIGH,
+    "qa.propose_plan_tasks": ReasoningLevel.HIGH,
+    "strategy.propose_plan_guidance": ReasoningLevel.HIGH,
+    "governance.merge_plan": ReasoningLevel.HIGH,
+    "governance.review_plan": ReasoningLevel.HIGH,
+    "governance.review": ReasoningLevel.HIGH,
+    "governance.define_done": ReasoningLevel.HIGH,
+    "data.analyze_failure": ReasoningLevel.HIGH,
+    "governance.root_cause_analysis": ReasoningLevel.HIGH,
+    "strategy.corrective_plan": ReasoningLevel.HIGH,
+    "governance.closeout_decision": ReasoningLevel.HIGH,
+}
+
+#: The ``config_overrides`` key an agent profile uses to override the declaration.
+REASONING_OVERRIDE_KEY = "reasoning"
+
+
+class UndeclaredReasoningLevel(LookupError):
+    """A capability generates without declaring how much reasoning it wants."""
+
+
+def default_reasoning_level(capability_id: str) -> str:
+    """The level ``capability_id`` declares. Raises for a capability that declares none."""
+    try:
+        return REASONING_BY_CAPABILITY[capability_id]
+    except KeyError:
+        raise UndeclaredReasoningLevel(
+            f"capability {capability_id!r} declares no reasoning level; "
+            "add it to REASONING_BY_CAPABILITY (squadops.capabilities.reasoning_policy)"
+        ) from None
+
+
+def resolve_reasoning_level(
+    capability_id: str,
+    *,
+    agent_overrides: Mapping[str, Any],
+    model_name: str | None,
+) -> str | None:
+    """The level to send for one generation, or ``None`` to send nothing.
+
+    capability declaration → ``config_overrides.reasoning`` → the model's dial.
+    ``None`` when the model is unknown to the registry or declares no reasoning
+    channel: nothing is sent and the wire is what it was before #927. The
+    override's value is validated where profiles are (``validate_agent_entries``),
+    not re-checked here.
+    """
+    level = agent_overrides.get(REASONING_OVERRIDE_KEY, default_reasoning_level(capability_id))
+    spec = get_model_spec(model_name) if model_name else None
+    if spec is None or spec.reasoning_control == ReasoningControl.NONE:
+        return None
+    return level
+
+
+def reasoning_kwargs(level: str | None) -> dict[str, str]:
+    """The ``chat()`` kwargs for a resolved level — ``{}`` when nothing is to be sent.
+
+    So a call site can ``chat_kwargs.update(reasoning_kwargs(level))`` and stay a
+    straight line; the develop/qa/builder handlers build their kwargs by hand
+    (the duplication #929 owns) and each would otherwise grow the same branch.
+    """
+    return {} if level is None else {"reasoning": level}

--- a/src/squadops/cycles/models.py
+++ b/src/squadops/cycles/models.py
@@ -183,6 +183,7 @@ ALLOWED_CONFIG_OVERRIDE_KEYS = frozenset(
         "temperature",
         "max_completion_tokens",
         "timeout_seconds",
+        "reasoning",  # a ReasoningLevel, overriding the capability's declaration (#927)
     }
 )
 

--- a/src/squadops/cycles/profile_utils.py
+++ b/src/squadops/cycles/profile_utils.py
@@ -8,6 +8,7 @@ from squadops.cycles.models import (
     ALLOWED_CONFIG_OVERRIDE_KEYS,
     ProfileValidationError,
 )
+from squadops.llm.models import REASONING_LEVELS
 
 # Profile ID constraints.
 _PROFILE_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9\-]{0,62}[a-z0-9]$")
@@ -49,6 +50,23 @@ def validate_config_overrides(overrides: dict) -> list[str]:
     return sorted(set(overrides.keys()) - ALLOWED_CONFIG_OVERRIDE_KEYS)
 
 
+def validate_reasoning_override(overrides: dict) -> list[str]:
+    """Errors for a ``reasoning`` override whose value is not a ReasoningLevel (#927).
+
+    Checked here, at the profile boundary, because nothing downstream re-checks
+    it: a misspelt level would reach the adapter and be sent as "reasoning on".
+    """
+    if "reasoning" not in overrides:
+        return []
+    level = overrides["reasoning"]
+    if level in REASONING_LEVELS:
+        return []
+    return [
+        f"config_overrides.reasoning must be one of {', '.join(sorted(REASONING_LEVELS))}; "
+        f"got {level!r}"
+    ]
+
+
 def validate_agent_entries(agents: list[dict]) -> list[str]:
     """Validate agent entries, returning a list of error messages.
 
@@ -74,5 +92,6 @@ def validate_agent_entries(agents: list[dict]) -> list[str]:
         unknown = validate_config_overrides(overrides)
         if unknown:
             errors.append(f"agents[{i}]: unknown config_overrides keys: {', '.join(unknown)}")
+        errors.extend(f"agents[{i}]: {e}" for e in validate_reasoning_override(overrides))
 
     return errors

--- a/src/squadops/llm/model_registry.py
+++ b/src/squadops/llm/model_registry.py
@@ -13,13 +13,28 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 
+class ReasoningControl:
+    """Which reasoning dial a model exposes — a model fact, not a provider one (#927).
+
+    The same weights reach their reasoning channel the same way on every
+    server; what differs per provider is only the wire spelling, which the
+    adapter owns. Declared per entry, no default: a model whose dial is not
+    stated is a registry gap, not a model that reasons silently.
+    """
+
+    NONE = "none"  # no reasoning channel to control (qwen2.5, llama3)
+    TOGGLE = "toggle"  # on/off only — qwen3-family ``think`` / ``enable_thinking``
+    EFFORT = "effort"  # graded low/medium/high — gpt-oss-family ``reasoning_effort``
+
+
 @dataclass(frozen=True)
 class ModelSpec:
-    """Context window and completion budget for a known model."""
+    """Context window, completion budget and reasoning dial for a known model."""
 
     name: str
     context_window: int
     default_max_completion: int
+    reasoning_control: str
 
 
 MODEL_SPECS: dict[str, ModelSpec] = {
@@ -27,16 +42,19 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         name="qwen2.5:7b",
         context_window=32_768,
         default_max_completion=4_096,
+        reasoning_control=ReasoningControl.NONE,
     ),
     "qwen2.5:32b": ModelSpec(
         name="qwen2.5:32b",
         context_window=32_768,
         default_max_completion=8_192,
+        reasoning_control=ReasoningControl.NONE,
     ),
     "qwen2.5:72b": ModelSpec(
         name="qwen2.5:72b",
         context_window=131_072,
         default_max_completion=16_384,
+        reasoning_control=ReasoningControl.NONE,
     ),
     # qwen3.6:27b is the uniform model used by the full
     # profile on DGX Spark. Without a registry entry, get_model_spec()
@@ -54,6 +72,10 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         name="qwen3.6:27b",
         context_window=131_072,
         default_max_completion=8_192,
+        # qwen3-family: thinking is on by default and switchable per request.
+        # #924 measured the same fill brief at 5,727 completion tokens with it
+        # on and 413 with it off — the dial is the budget.
+        reasoning_control=ReasoningControl.TOGGLE,
     ),
     # qwen3.8:27b is the V38 comparison arm (full-38 profile). The completion
     # clamp is deliberately IDENTICAL to qwen3.6:27b's: the V38 window compares
@@ -65,11 +87,13 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         name="qwen3.8:27b",
         context_window=262_144,
         default_max_completion=8_192,
+        reasoning_control=ReasoningControl.TOGGLE,
     ),
     "llama3:70b": ModelSpec(
         name="llama3:70b",
         context_window=131_072,
         default_max_completion=16_384,
+        reasoning_control=ReasoningControl.NONE,
     ),
 }
 

--- a/src/squadops/llm/models.py
+++ b/src/squadops/llm/models.py
@@ -7,6 +7,33 @@ Part of SIP-0.8.7 Infrastructure Ports Migration.
 from dataclasses import dataclass
 
 
+class ReasoningLevel:
+    """How much reasoning a generation asks for — the port's vocabulary (#927).
+
+    A level, never a provider's switch. Ollama maps it onto ``think``, an
+    OpenAI-compatible surface onto whichever dial the model exposes (a toggle or
+    an effort), and a provider with no control accepts it and sends nothing. It
+    is a *request*, not a guarantee: an adapter maps down to what its wire can
+    express and never fails a call over it.
+
+    ``NONE`` is the level for a transcription — an output the prompt already
+    determines (filling scaffold slots, a verdict from evidence, a stored
+    report). The graded levels are for an argument — an output that chooses
+    (authoring a design, analysing a failure). The capability declares which it
+    is; see ``squadops.capabilities.reasoning_policy``.
+    """
+
+    NONE = "none"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+REASONING_LEVELS: frozenset[str] = frozenset(
+    {ReasoningLevel.NONE, ReasoningLevel.LOW, ReasoningLevel.MEDIUM, ReasoningLevel.HIGH}
+)
+
+
 @dataclass(frozen=True)
 class LLMRequest:
     """Request for LLM text generation.
@@ -20,6 +47,7 @@ class LLMRequest:
     max_tokens: int = 4000
     format: str | None = None  # "json" for structured output
     timeout_seconds: float = 180.0
+    reasoning: str | None = None  # a ReasoningLevel; None = the provider's own default
 
 
 @dataclass(frozen=True)

--- a/src/squadops/llm/router.py
+++ b/src/squadops/llm/router.py
@@ -52,6 +52,7 @@ class LLMRouter:
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        reasoning: str | None = None,
     ) -> ChatMessage:
         """Chat with the LLM.
 
@@ -71,6 +72,7 @@ class LLMRouter:
             max_tokens=max_tokens,
             temperature=temperature,
             timeout_seconds=timeout_seconds,
+            reasoning=reasoning,
         )
 
     async def chat_stream(
@@ -80,6 +82,7 @@ class LLMRouter:
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        reasoning: str | None = None,
     ) -> AsyncIterator[str]:
         """Stream chat response as plain text chunks.
 
@@ -91,6 +94,7 @@ class LLMRouter:
             max_tokens=max_tokens,
             temperature=temperature,
             timeout_seconds=timeout_seconds,
+            reasoning=reasoning,
         ):
             yield chunk
 
@@ -101,6 +105,7 @@ class LLMRouter:
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        reasoning: str | None = None,
     ) -> ChatMessage:
         """Stream chat internally, return complete ChatMessage with usage.
 
@@ -112,6 +117,7 @@ class LLMRouter:
             max_tokens=max_tokens,
             temperature=temperature,
             timeout_seconds=timeout_seconds,
+            reasoning=reasoning,
         )
 
     def list_models(self) -> list[str]:

--- a/src/squadops/ports/llm/provider.py
+++ b/src/squadops/ports/llm/provider.py
@@ -22,6 +22,7 @@ class LLMCapability:
     MODEL_MANAGEMENT = "model_management"
     STREAMING_USAGE = "streaming_usage"
     THINKING_TOKENS = "thinking_tokens"
+    REASONING_CONTROL = "reasoning_control"
 
 
 class LLMPort(ABC):
@@ -64,6 +65,7 @@ class LLMPort(ABC):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        reasoning: str | None = None,
     ) -> ChatMessage:
         """Chat with the LLM using message history.
 
@@ -73,6 +75,13 @@ class LLMPort(ABC):
             max_tokens: Maximum completion tokens (adapter default if None)
             temperature: Sampling temperature (adapter default if None)
             timeout_seconds: Request timeout (adapter default if None)
+            reasoning: A :class:`~squadops.llm.models.ReasoningLevel` — how much
+                reasoning this generation wants. ``None`` sends nothing and
+                leaves the provider's own default in force. A request, not a
+                guarantee: the adapter maps it onto whatever dial the wire has
+                (Ollama ``think``, a chat-template toggle, an effort) and an
+                adapter with no dial accepts it silently — see
+                ``capabilities()[REASONING_CONTROL]`` (#927).
 
         Returns:
             Assistant's response message
@@ -91,6 +100,7 @@ class LLMPort(ABC):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        reasoning: str | None = None,
     ) -> AsyncIterator[str]:
         """Stream chat response as plain text chunks.
 
@@ -110,6 +120,7 @@ class LLMPort(ABC):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        reasoning: str | None = None,
     ) -> ChatMessage:
         """Stream chat internally for connection liveness, return complete ChatMessage with usage.
 
@@ -129,6 +140,7 @@ class LLMPort(ABC):
             max_tokens=max_tokens,
             temperature=temperature,
             timeout_seconds=timeout_seconds,
+            reasoning=reasoning,
         )
 
     @abstractmethod
@@ -187,6 +199,10 @@ class LLMPort(ABC):
         - ``thinking_tokens``: reasoning tokens are reported separately from
           content. False here does not mean the model does not think — only that
           this adapter cannot distinguish the two (#410).
+        - ``reasoning_control``: a ``reasoning`` level passed to the generation
+          methods changes what is sent on the wire. False means the level is
+          accepted and dropped — the call still succeeds, the model keeps its
+          own posture (#927).
 
         Defaults to all-False: an adapter that declares nothing is treated as
         supporting nothing. Failing closed keeps a silent omission from
@@ -197,6 +213,7 @@ class LLMPort(ABC):
             LLMCapability.MODEL_MANAGEMENT: False,
             LLMCapability.STREAMING_USAGE: False,
             LLMCapability.THINKING_TOKENS: False,
+            LLMCapability.REASONING_CONTROL: False,
         }
 
     def supports(self, capability: str) -> bool:

--- a/src/squadops/telemetry/models.py
+++ b/src/squadops/telemetry/models.py
@@ -155,3 +155,7 @@ class GenerationRecord:
     # SIP-0084: prompt-to-generation linkage for Langfuse
     prompt_name: str | None = None
     prompt_version: int | None = None
+    # #927: the reasoning level this generation was sent with (a ReasoningLevel),
+    # None when none was sent — so "how much did this call think" is readable
+    # per generation rather than inferred from a token count.
+    reasoning: str | None = None

--- a/tests/unit/capabilities/test_cycle_task_handlers.py
+++ b/tests/unit/capabilities/test_cycle_task_handlers.py
@@ -568,7 +568,7 @@ class TestConfigOverridesFlow:
         ids=[c.__name__ for c in HANDLER_CLASSES],
     )
     async def test_no_level_is_sent_for_a_model_without_the_dial(self, cls, mock_context):
-        """qwen2.5 has no reasoning channel; Ollama rejects ``think`` for it,
+        """qwen2.5 has no reasoning channel; Ollama 400s on ``think: true`` for it,
         so a level leaking through would 400 every call on the lite profile."""
         handler = cls()
         inputs = {

--- a/tests/unit/capabilities/test_cycle_task_handlers.py
+++ b/tests/unit/capabilities/test_cycle_task_handlers.py
@@ -30,6 +30,7 @@ from squadops.capabilities.handlers.cycle_tasks import (
     QAValidateHandler,
     StrategyAnalyzeHandler,
 )
+from squadops.capabilities.reasoning_policy import REASONING_BY_CAPABILITY
 from squadops.llm.exceptions import LLMConnectionError, LLMModelNotFoundError, LLMTimeoutError
 from squadops.llm.models import ChatMessage
 
@@ -538,6 +539,47 @@ class TestConfigOverridesFlow:
 
         call_kwargs = mock_context.ports.llm.chat_stream_with_usage.call_args[1]
         assert "model" not in call_kwargs
+
+    @pytest.mark.parametrize(
+        "cls",
+        HANDLER_CLASSES,
+        ids=[c.__name__ for c in HANDLER_CLASSES],
+    )
+    async def test_declared_reasoning_level_reaches_chat_on_a_switchable_model(
+        self, cls, mock_context
+    ):
+        """#927: the capability's declaration, not the model's default posture,
+        decides how much this call thinks — and it is on the wire, not merely
+        resolved. The bug: the level resolved and never sent."""
+        handler = cls()
+        inputs = {
+            "prd": "Build a widget",
+            "agent_model": "qwen3.6:27b",
+            "agent_config_overrides": {},
+        }
+        await handler.handle(mock_context, inputs)
+
+        call_kwargs = mock_context.ports.llm.chat_stream_with_usage.call_args[1]
+        assert call_kwargs["reasoning"] == REASONING_BY_CAPABILITY[handler.capability_id]
+
+    @pytest.mark.parametrize(
+        "cls",
+        HANDLER_CLASSES,
+        ids=[c.__name__ for c in HANDLER_CLASSES],
+    )
+    async def test_no_level_is_sent_for_a_model_without_the_dial(self, cls, mock_context):
+        """qwen2.5 has no reasoning channel; Ollama rejects ``think`` for it,
+        so a level leaking through would 400 every call on the lite profile."""
+        handler = cls()
+        inputs = {
+            "prd": "Build a widget",
+            "agent_model": "qwen2.5:7b",
+            "agent_config_overrides": {"reasoning": "high"},
+        }
+        await handler.handle(mock_context, inputs)
+
+        call_kwargs = mock_context.ports.llm.chat_stream_with_usage.call_args[1]
+        assert "reasoning" not in call_kwargs
 
     @pytest.mark.parametrize(
         "cls",

--- a/tests/unit/capabilities/test_reasoning_policy.py
+++ b/tests/unit/capabilities/test_reasoning_policy.py
@@ -3,7 +3,7 @@
 The port carries a level; this is where the level comes from. Two classes of
 bug: a capability generating with no declaration (the channel silently on —
 #924's condition), and a resolved level reaching a model that cannot take it
-(Ollama rejects ``think`` for a model without the channel).
+(Ollama answers ``think: true`` with a 400 for a model without the channel).
 """
 
 from __future__ import annotations
@@ -68,7 +68,7 @@ class TestResolution:
 
     @pytest.mark.parametrize("model", ["qwen2.5:7b", "unregistered:1b", None])
     def test_a_model_without_the_dial_gets_no_level(self, model):
-        """qwen2.5 has no channel and Ollama 400s on ``think`` for it; an
+        """qwen2.5 has no channel and Ollama 400s on ``think: true`` for it; an
         unregistered model is #1145's preflight finding, not a guess here; no
         model at all means the adapter's default, whose dial is unknown."""
         assert (

--- a/tests/unit/capabilities/test_reasoning_policy.py
+++ b/tests/unit/capabilities/test_reasoning_policy.py
@@ -1,0 +1,93 @@
+"""The reasoning declaration and its resolution (#927).
+
+The port carries a level; this is where the level comes from. Two classes of
+bug: a capability generating with no declaration (the channel silently on —
+#924's condition), and a resolved level reaching a model that cannot take it
+(Ollama rejects ``think`` for a model without the channel).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.bootstrap.handlers import HANDLER_CONFIGS
+from squadops.capabilities.reasoning_policy import (
+    REASONING_BY_CAPABILITY,
+    UndeclaredReasoningLevel,
+    default_reasoning_level,
+    reasoning_kwargs,
+    resolve_reasoning_level,
+)
+from squadops.llm.models import REASONING_LEVELS, ReasoningLevel
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+
+class TestDeclarations:
+    @pytest.mark.parametrize(
+        "handler_cls", [cls for cls, _ in HANDLER_CONFIGS], ids=lambda c: c.__name__
+    )
+    def test_every_registered_handler_declares_a_level(self, handler_cls):
+        """A handler registered for dispatch without an entry would generate
+        with the model's own posture — reasoning on, unread, unrecorded — which
+        is exactly what #924 found on qa.test. This is the CI guard the policy
+        module promises."""
+        assert handler_cls().capability_id in REASONING_BY_CAPABILITY
+
+    def test_every_declared_level_is_a_known_level(self):
+        """A misspelt level ("hgih") would reach Ollama as ``think: true`` and
+        vLLM as an invalid effort — neither side rejects it."""
+        for capability_id, level in REASONING_BY_CAPABILITY.items():
+            assert level in REASONING_LEVELS, capability_id
+
+    def test_undeclared_capability_raises_rather_than_defaults(self):
+        with pytest.raises(UndeclaredReasoningLevel, match="no.such.capability"):
+            default_reasoning_level("no.such.capability")
+
+    def test_the_two_measured_anchors(self):
+        """#924's two ends. The fill is a transcription (413 tokens without the
+        channel, 5,727 with); the manifest is an argument. Flipping the first
+        restores the 13.9x waste silently; flipping the second strips reasoning
+        from the one output that chooses endpoints and statuses."""
+        assert REASONING_BY_CAPABILITY["qa.test"] == ReasoningLevel.NONE
+        assert REASONING_BY_CAPABILITY["development.author_manifest"] == ReasoningLevel.HIGH
+
+
+class TestResolution:
+    def test_declaration_applies_on_a_switchable_model(self):
+        assert (
+            resolve_reasoning_level("qa.test", agent_overrides={}, model_name="qwen3.6:27b")
+            == ReasoningLevel.NONE
+        )
+
+    def test_agent_override_beats_the_declaration(self):
+        level = resolve_reasoning_level(
+            "qa.test", agent_overrides={"reasoning": "high"}, model_name="qwen3.6:27b"
+        )
+        assert level == ReasoningLevel.HIGH
+
+    @pytest.mark.parametrize("model", ["qwen2.5:7b", "unregistered:1b", None])
+    def test_a_model_without_the_dial_gets_no_level(self, model):
+        """qwen2.5 has no channel and Ollama 400s on ``think`` for it; an
+        unregistered model is #1145's preflight finding, not a guess here; no
+        model at all means the adapter's default, whose dial is unknown."""
+        assert (
+            resolve_reasoning_level(
+                "development.author_manifest", agent_overrides={}, model_name=model
+            )
+            is None
+        )
+
+    def test_override_does_not_beat_the_model(self):
+        """An operator cannot request reasoning from a model that has none —
+        the clamp is the last word, as it is for the completion budget."""
+        assert (
+            resolve_reasoning_level(
+                "qa.test", agent_overrides={"reasoning": "high"}, model_name="qwen2.5:7b"
+            )
+            is None
+        )
+
+    def test_reasoning_kwargs_is_empty_for_nothing_and_one_key_otherwise(self):
+        assert reasoning_kwargs(None) == {}
+        assert reasoning_kwargs(ReasoningLevel.LOW) == {"reasoning": "low"}

--- a/tests/unit/capabilities/test_repair_handlers.py
+++ b/tests/unit/capabilities/test_repair_handlers.py
@@ -12,12 +12,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from squadops.capabilities.handlers.impl.repair_handlers import QATestRepairHandler
 from squadops.capabilities.handlers.repair_tasks import (
     DataAnalyzeVerificationHandler,
     DevelopmentRepairHandler,
     GovernanceRootCauseHandler,
     StrategyCorrectivePlanHandler,
 )
+from squadops.capabilities.reasoning_policy import REASONING_BY_CAPABILITY
 
 pytestmark = [pytest.mark.domain_pulse_checks]
 
@@ -330,3 +332,53 @@ class TestPriorRepairRejectionReachesThePrompt:
         from squadops.capabilities.handlers.impl.repair_handlers import _format_failure_summary
 
         assert "PRIOR REPAIR REJECTED" not in _format_failure_summary({"error": "x"}, None)
+
+
+class TestRepairReasoningLevel:
+    """#927 on the base ``_build_chat_kwargs`` path every repair handler rides:
+    the capability's declared level reaches ``chat()``, clamped by the model's
+    dial. The bug: a repair generating with the model's own posture — the
+    12,314-token repair #1011 clamped was mostly thinking."""
+
+    def test_dev_repair_sends_its_declared_level_on_a_switchable_model(self):
+        kwargs = DevelopmentRepairHandler()._build_chat_kwargs(
+            {"agent_model": "qwen3.8:27b", "agent_config_overrides": {}}
+        )
+        assert kwargs["reasoning"] == REASONING_BY_CAPABILITY["development.correction_repair"]
+
+    def test_qa_repair_switches_the_channel_off(self):
+        """The qa-owned repair is a transcription of a failing assertion into a
+        correct one; #924's measurement says the channel is the budget here."""
+        kwargs = QATestRepairHandler()._build_chat_kwargs(
+            {"agent_model": "qwen3.8:27b", "agent_config_overrides": {}}
+        )
+        assert kwargs["reasoning"] == "none"
+
+    def test_profile_override_wins(self):
+        kwargs = DevelopmentRepairHandler()._build_chat_kwargs(
+            {"agent_model": "qwen3.8:27b", "agent_config_overrides": {"reasoning": "none"}}
+        )
+        assert kwargs["reasoning"] == "none"
+
+    @pytest.mark.parametrize("model", ["qwen2.5:7b", "totally-unregistered:1b"])
+    def test_no_level_for_a_model_without_the_dial(self, model):
+        kwargs = DevelopmentRepairHandler()._build_chat_kwargs(
+            {"agent_model": model, "agent_config_overrides": {}}
+        )
+        assert "reasoning" not in kwargs
+
+    async def test_level_reaches_the_llm_call(self):
+        """Wiring half: the resolved level arrives at chat_stream_with_usage."""
+        h = DevelopmentRepairHandler()
+        ctx = _make_context(llm_response="repaired")
+        await h.handle(
+            ctx,
+            {
+                "prd": "p",
+                "agent_model": "qwen3.8:27b",
+                "agent_config_overrides": {},
+                "failure_context": "traceback",
+            },
+        )
+        call_kwargs = ctx.ports.llm.chat_stream_with_usage.call_args.kwargs
+        assert call_kwargs["reasoning"] == "medium"

--- a/tests/unit/cycles/test_profile_utils.py
+++ b/tests/unit/cycles/test_profile_utils.py
@@ -90,6 +90,11 @@ class TestValidateConfigOverrides:
         result = validate_config_overrides({"temperature": 0.7, "bad_key": 1, "another_bad": 2})
         assert result == ["another_bad", "bad_key"]
 
+    def test_reasoning_is_an_allowed_key(self):
+        """#927: the override the plan's Reasoning pack promises operators —
+        rejected as unknown, the profile could never turn the channel off."""
+        assert validate_config_overrides({"reasoning": "none"}) == []
+
     def test_empty_dict(self):
         assert validate_config_overrides({}) == []
 
@@ -131,6 +136,36 @@ class TestValidateAgentEntries:
         ]
         errors = validate_agent_entries(agents)
         assert any("unknown config_overrides keys" in e for e in errors)
+
+    @pytest.mark.parametrize("bad", ["hgih", "", None, 2, True])
+    def test_reasoning_override_must_be_a_level(self, bad):
+        """#927: nothing downstream re-checks the value — a misspelt level
+        would reach Ollama as ``think: true``. Rejected at the profile, named."""
+        agents = [
+            {
+                "agent_id": "neo",
+                "role": "dev",
+                "model": "qwen3.6:27b",
+                "config_overrides": {"reasoning": bad},
+            }
+        ]
+        errors = validate_agent_entries(agents)
+        assert errors == [
+            "agents[0]: config_overrides.reasoning must be one of high, low, medium, none; "
+            f"got {bad!r}"
+        ]
+
+    @pytest.mark.parametrize("level", ["none", "low", "medium", "high"])
+    def test_reasoning_override_accepts_every_level(self, level):
+        agents = [
+            {
+                "agent_id": "neo",
+                "role": "dev",
+                "model": "qwen3.6:27b",
+                "config_overrides": {"reasoning": level},
+            }
+        ]
+        assert validate_agent_entries(agents) == []
 
     def test_missing_fields_use_defaults(self):
         agents = [{"agent_id": "neo", "role": "dev", "model": "qwen2.5:7b"}]

--- a/tests/unit/llm/conformance.py
+++ b/tests/unit/llm/conformance.py
@@ -68,6 +68,10 @@ class AdapterCase:
     # Exact rate when the provider reports timings; None when the adapter derives
     # it from wall-clock, which is machine-dependent and range-checked instead.
     tokens_per_second: float | None
+    # A model the registry declares a reasoning dial for (#927). The reasoning
+    # assertion needs one: an adapter that maps by the model's dial sends nothing
+    # for a dial-less model, which is the contract, not a defect.
+    reasoning_model: str
 
     def __str__(self) -> str:  # pytest id
         return self.name
@@ -325,6 +329,7 @@ ADAPTER_CASES: list[AdapterCase] = [
         prompt_tokens=_PROMPT_EVAL_COUNT,
         completion_tokens=_EVAL_COUNT,
         tokens_per_second=6.0,  # exact: derived from reported ns timings
+        reasoning_model="qwen3.6:27b",
     ),
     AdapterCase(
         name="vllm",
@@ -342,6 +347,9 @@ ADAPTER_CASES: list[AdapterCase] = [
         prompt_tokens=_VLLM_PROMPT_TOKENS,
         completion_tokens=_VLLM_COMPLETION_TOKENS,
         tokens_per_second=None,  # wall-clock derived; no timing field in the shape
+        # The registry is keyed on the name the adapter is handed; a real vLLM
+        # serves HF paths, whose entries are #1145/#1159's to add.
+        reasoning_model="qwen3.6:27b",
     ),
 ]
 

--- a/tests/unit/llm/test_chat_stream.py
+++ b/tests/unit/llm/test_chat_stream.py
@@ -37,6 +37,7 @@ class _StreamingLLM(LLMPort):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        reasoning: str | None = None,
     ) -> AsyncIterator[str]:
         for chunk in self._chunks:
             yield chunk
@@ -282,6 +283,7 @@ class TestRouterChatStreamForwarding:
                 max_tokens=10,
                 temperature=0.1,
                 timeout_seconds=5.0,
+                reasoning="none",
             )
         ]
         assert chunks == ["ok"]
@@ -290,6 +292,7 @@ class TestRouterChatStreamForwarding:
             "max_tokens": 10,
             "temperature": 0.1,
             "timeout_seconds": 5.0,
+            "reasoning": "none",
         }
 
 

--- a/tests/unit/llm/test_llm_port_conformance.py
+++ b/tests/unit/llm/test_llm_port_conformance.py
@@ -24,7 +24,7 @@ from squadops.llm.exceptions import (
     LLMModelNotFoundError,
     LLMTimeoutError,
 )
-from squadops.llm.models import ChatMessage, LLMRequest, ModelInfo
+from squadops.llm.models import ChatMessage, LLMRequest, ModelInfo, ReasoningLevel
 from squadops.ports.llm.provider import LLMCapability
 from tests.unit.llm.conformance import ADAPTER_CASES, raises, status, wire
 
@@ -264,6 +264,7 @@ class TestCapabilityHonesty:
             LLMCapability.MODEL_MANAGEMENT,
             LLMCapability.STREAMING_USAGE,
             LLMCapability.THINKING_TOKENS,
+            LLMCapability.REASONING_CONTROL,
         }
 
     async def test_supports_is_false_for_an_undeclared_capability(self, case):
@@ -292,6 +293,34 @@ class TestCapabilityHonesty:
                     await adapter.pull_model("qwen2.5:7b")
                 with pytest.raises(NotImplementedError):
                     await adapter.delete_model("qwen2.5:7b")
+
+    async def test_reasoning_control_declaration_matches_behavior(self, case):
+        """Declared True ⇒ a level changes the request, and no level leaves it
+        exactly as it was (the pre-#927 wire, byte for byte — a level that
+        leaked in unasked would change every generation's posture). Declared
+        False ⇒ the three requests are identical: the level is accepted and
+        dropped, never turned into a rejected call."""
+        adapter = case.build()
+        bodies: list[bytes] = []
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            bodies.append(request.content)
+            return case.ok(request)
+
+        with wire(capture):
+            await adapter.chat(_messages(), model=case.reasoning_model)
+            await adapter.chat(
+                _messages(), model=case.reasoning_model, reasoning=ReasoningLevel.NONE
+            )
+            await adapter.chat(
+                _messages(), model=case.reasoning_model, reasoning=ReasoningLevel.HIGH
+            )
+        bare, none, high = bodies
+        if adapter.supports(LLMCapability.REASONING_CONTROL):
+            assert none != high
+            assert bare not in (none, high)
+        else:
+            assert bare == none == high
 
     async def test_streaming_usage_declaration_matches_behavior(self, case):
         """Declared True means real counts, not the port's chat() fallback —

--- a/tests/unit/llm/test_model_registry.py
+++ b/tests/unit/llm/test_model_registry.py
@@ -9,9 +9,31 @@ class TestModelSpec:
     """Tests for ModelSpec dataclass."""
 
     def test_frozen(self):
-        spec = ModelSpec(name="test", context_window=8192, default_max_completion=4096)
+        spec = ModelSpec(
+            name="test", context_window=8192, default_max_completion=4096, reasoning_control="none"
+        )
         with pytest.raises(AttributeError):
             spec.name = "changed"  # type: ignore[misc]
+
+    def test_every_spec_declares_a_known_reasoning_dial(self):
+        """#927: an entry whose dial is missing or misspelled makes the vLLM
+        mapping silently send nothing and the handler-side clamp silently drop
+        the level — the reasoning channel stays on, unobserved."""
+        from squadops.llm.model_registry import ReasoningControl
+
+        known = {ReasoningControl.NONE, ReasoningControl.TOGGLE, ReasoningControl.EFFORT}
+        for spec in MODEL_SPECS.values():
+            assert spec.reasoning_control in known, spec.name
+
+    def test_qwen3_family_is_switchable_and_qwen25_is_not(self):
+        """The two families the profiles run: #924's dial exists on qwen3 and
+        Ollama rejects ``think`` on qwen2.5 — a swapped declaration either
+        leaves the 13.9× channel on or 400s every qwen2.5 call."""
+        from squadops.llm.model_registry import ReasoningControl
+
+        assert MODEL_SPECS["qwen3.6:27b"].reasoning_control == ReasoningControl.TOGGLE
+        assert MODEL_SPECS["qwen3.8:27b"].reasoning_control == ReasoningControl.TOGGLE
+        assert MODEL_SPECS["qwen2.5:7b"].reasoning_control == ReasoningControl.NONE
 
     def test_all_specs_context_exceeds_completion(self):
         """Every registered model must have context_window > default_max_completion."""

--- a/tests/unit/llm/test_model_registry.py
+++ b/tests/unit/llm/test_model_registry.py
@@ -27,7 +27,7 @@ class TestModelSpec:
 
     def test_qwen3_family_is_switchable_and_qwen25_is_not(self):
         """The two families the profiles run: #924's dial exists on qwen3 and
-        Ollama rejects ``think`` on qwen2.5 — a swapped declaration either
+        Ollama 400s on ``think: true`` for qwen2.5 — a swapped declaration either
         leaves the 13.9× channel on or 400s every qwen2.5 call."""
         from squadops.llm.model_registry import ReasoningControl
 

--- a/tests/unit/llm/test_ollama_adapter.py
+++ b/tests/unit/llm/test_ollama_adapter.py
@@ -6,7 +6,7 @@ import pytest
 
 from adapters.llm.ollama import OllamaAdapter
 from squadops.llm.exceptions import LLMTimeoutError
-from squadops.llm.models import ChatMessage, LLMRequest
+from squadops.llm.models import ChatMessage, LLMRequest, ReasoningLevel
 
 
 class TestOllamaAdapter:
@@ -125,6 +125,55 @@ class TestOllamaAdapterAsync:
             call_kwargs = mock_client.post.call_args
             payload = call_kwargs.kwargs["json"]
             assert payload["options"]["num_predict"] == 8000
+
+    @pytest.mark.parametrize(
+        ("reasoning", "think"),
+        [
+            (ReasoningLevel.NONE, False),
+            (ReasoningLevel.LOW, True),
+            (ReasoningLevel.MEDIUM, True),
+            (ReasoningLevel.HIGH, True),
+        ],
+    )
+    async def test_chat_reasoning_maps_to_think(self, reasoning, think):
+        """#927: the port's level reaches Ollama as its ``think`` flag —
+        ``none`` off, every graded level on (the only dial the dialect has).
+        The bug: a level accepted at the port and never sent, so the 5,727-token
+        fill #924 measured keeps paying for a channel nobody reads."""
+        adapter = OllamaAdapter()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "message": {"role": "assistant", "content": "response"},
+        }
+        with patch.object(adapter, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            await adapter.chat([ChatMessage(role="user", content="Hello")], reasoning=reasoning)
+
+            payload = mock_client.post.call_args.kwargs["json"]
+            assert payload["think"] is think
+
+    async def test_chat_without_reasoning_sends_no_think(self):
+        """No level ⇒ no ``think`` key: the payload is the pre-#927 one, so a
+        model with no reasoning channel (Ollama rejects ``think`` for those)
+        and every unchanged caller keep working."""
+        adapter = OllamaAdapter()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "message": {"role": "assistant", "content": "response"},
+        }
+        with patch.object(adapter, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            await adapter.chat([ChatMessage(role="user", content="Hello")], max_tokens=10)
+
+            assert "think" not in mock_client.post.call_args.kwargs["json"]
 
     async def test_chat_with_temperature(self):
         """chat() forwards temperature in options."""

--- a/tests/unit/llm/test_ollama_adapter.py
+++ b/tests/unit/llm/test_ollama_adapter.py
@@ -158,7 +158,7 @@ class TestOllamaAdapterAsync:
 
     async def test_chat_without_reasoning_sends_no_think(self):
         """No level ⇒ no ``think`` key: the payload is the pre-#927 one, so a
-        model with no reasoning channel (Ollama rejects ``think`` for those)
+        model with no reasoning channel (Ollama 400s on ``think: true`` for those)
         and every unchanged caller keep working."""
         adapter = OllamaAdapter()
         mock_response = MagicMock()

--- a/tests/unit/llm/test_ports.py
+++ b/tests/unit/llm/test_ports.py
@@ -25,6 +25,7 @@ class _ConcreteLLM(LLMPort):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        reasoning: str | None = None,
     ) -> ChatMessage:
         self.last_chat_kwargs = {
             "model": model,
@@ -41,6 +42,7 @@ class _ConcreteLLM(LLMPort):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        reasoning: str | None = None,
     ) -> AsyncIterator[str]:
         self.last_chat_kwargs = {
             "model": model,

--- a/tests/unit/llm/test_vllm_adapter.py
+++ b/tests/unit/llm/test_vllm_adapter.py
@@ -21,8 +21,9 @@ import json
 import httpx
 import pytest
 
-from adapters.llm.vllm import VLLMAdapter
-from squadops.llm.models import ChatMessage
+from adapters.llm.vllm import VLLMAdapter, _reasoning_fields
+from squadops.llm.model_registry import ModelSpec, ReasoningControl
+from squadops.llm.models import ChatMessage, ReasoningLevel
 from tests.unit.llm.conformance import wire
 
 pytestmark = [pytest.mark.domain_orchestration]
@@ -182,3 +183,69 @@ class TestStreamingUsageFrame:
         assert message.content == "answer"
         assert message.completion_tokens == 6
         assert message.total_tokens == 10
+
+
+def _spec(dial: str) -> ModelSpec:
+    return ModelSpec(name="any", context_window=1, default_max_completion=1, reasoning_control=dial)
+
+
+class TestReasoningDials:
+    """#927: the OpenAI shape has no reasoning field; each model family has its
+    own, and the adapter picks by the dial the model spec declares. The bug each
+    case guards: the wrong field for the family — a ``reasoning_effort`` sent to
+    a qwen3 server is ignored and the channel stays on; a
+    ``chat_template_kwargs`` sent to gpt-oss does nothing."""
+
+    @pytest.mark.parametrize(
+        ("level", "enabled"),
+        [
+            (ReasoningLevel.NONE, False),
+            (ReasoningLevel.LOW, True),
+            (ReasoningLevel.HIGH, True),
+        ],
+    )
+    def test_toggle_dial_collapses_to_enable_thinking(self, level, enabled):
+        assert _reasoning_fields(_spec(ReasoningControl.TOGGLE), level) == {
+            "chat_template_kwargs": {"enable_thinking": enabled}
+        }
+
+    @pytest.mark.parametrize(
+        ("level", "effort"),
+        [
+            (ReasoningLevel.NONE, "low"),  # the dial cannot switch off; lowest effort
+            (ReasoningLevel.LOW, "low"),
+            (ReasoningLevel.MEDIUM, "medium"),
+            (ReasoningLevel.HIGH, "high"),
+        ],
+    )
+    def test_effort_dial_passes_the_level_through(self, level, effort):
+        assert _reasoning_fields(_spec(ReasoningControl.EFFORT), level) == {
+            "reasoning_effort": effort
+        }
+
+    @pytest.mark.parametrize("spec", [None, _spec(ReasoningControl.NONE)])
+    def test_no_dial_sends_nothing(self, spec):
+        """An unregistered model or one with no channel gets no field at all —
+        some backends reject unknown fields, and the port says a level is a
+        request, not a guarantee."""
+        assert _reasoning_fields(spec, ReasoningLevel.HIGH) == {}
+
+    async def test_level_reaches_the_wire_by_the_registered_dial(self):
+        """Wiring half: a registered toggle model's request carries the
+        chat-template switch, and the flat OpenAI fields are untouched."""
+        seen: list[dict] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(json.loads(request.content))
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                },
+            )
+
+        with wire(handler):
+            await _adapter().chat(_messages(), model="qwen3.6:27b", reasoning=ReasoningLevel.NONE)
+        assert seen[0]["chat_template_kwargs"] == {"enable_thinking": False}
+        assert "reasoning_effort" not in seen[0]

--- a/tests/unit/telemetry/test_langfuse_adapter.py
+++ b/tests/unit/telemetry/test_langfuse_adapter.py
@@ -279,6 +279,13 @@ class TestRedactionPreservesEveryOtherField:
     These tests pin both halves: the value that was lost, and the class of loss.
     """
 
+    def test_reasoning_level_survives_redaction(self, adapter):
+        """#927's field, added after the #793 fix: the copy-everything
+        ``replace`` must carry it, or LangFuse shows every generation with the
+        level unknown and the Reasoning pack's first prediction is unreadable."""
+        adapter.record_generation(_make_ctx(), _make_record(reasoning="none"), _make_layers())
+        assert adapter._buffer.get_nowait().payload[0].reasoning == "none"
+
     def test_tokens_per_second_survives_redaction(self, adapter):
         """The exact #793 defect. A populated throughput must reach the buffer."""
         adapter.record_generation(_make_ctx(), _make_record(tokens_per_second=10.6), _make_layers())


### PR DESCRIPTION
## What

The first item of the 1.7.0 Reasoning line (`docs/plans/1-7-0-plan.md` §2.1). The reasoning channel was paid for on every qwen3 generation, discarded unread, and invisible: #924 measured the deployed qa fill brief at **5,727** completion tokens with it on and **413** with it off — the same eight fences — and at a 2,500-token budget, 19,179 characters of thinking and an empty response. The first fix (#925) was rejected as a boolean on a handler and an Ollama `think` bool on a provider-neutral port. This is the design #927 asked for, in four commits:

**1. The port carries a level** — `reasoning: none | low | medium | high` (`ReasoningLevel`, `squadops/llm/models.py`) on `chat` / `chat_stream` / `chat_stream_with_usage` / `LLMRequest`. A request, not a guarantee; `None` sends nothing and the wire is byte-identical to 1.6.6.
- **Ollama**: `none → think:false`, any graded level → `think:true` (the dialect's only dial).
- **vLLM**: the OpenAI shape has no reasoning field; the adapter maps by the dial the *model spec* declares — `toggle` → `chat_template_kwargs.enable_thinking`, `effort` → `reasoning_effort` (`none` becomes `low`; that dial cannot switch off), no dial / unregistered → nothing.
- `LLMCapability.REASONING_CONTROL` declares whether a level reaches the wire; the conformance suite asserts the declaration against the actual request bodies for every adapter (`bare ≠ none ≠ high` iff declared).
- `ModelSpec.reasoning_control` is **required** on every registry entry (no default — an undeclared dial is a registry gap, not a model that reasons silently): qwen3.x `toggle`, qwen2.5/llama3 `none`.

**2. Every capability declares how much reasoning its output wants** — `capabilities/reasoning_policy.py`, one table: *reason where the output is an argument; don't where it is a transcription.* `qa.test` (fills slots), the repairs, verdicts and stored reports are `none`; develop/repair `medium`; the manifest, the analyses, the plan `high`. **No default**: an undeclared capability raises, and a test over `HANDLER_CONFIGS` makes a missing entry a CI failure. When #922 gives cycle capabilities a contract as data, the column moves there.

**3. Resolution is the chain every other knob uses** (SIP-0075 §3.2, #1011): declaration → `config_overrides.reasoning` (new allowed key; value validated at the profile boundary — a misspelt level would otherwise reach Ollama as `think: true`) → the model's dial (a channel-less model gets no level: Ollama answers `think: true` with a 400 for it). Wired through `_build_chat_kwargs` for every base-path and planning handler, and the three hand-rolled sites (develop, qa_test, builder) via a branchless splice — the duplication itself is #929's.

**4. `GenerationRecord.reasoning`** carries the sent level to LangFuse (the copy-everything `replace` keeps it — #793's class), so the Reasoning pack's first prediction — *the level resolves per capability* — is read per generation rather than inferred from a token count.

**Not in this PR, said plainly:** the read half (#410 — `message.thinking` captured and emitted); a CRP-level override (the #927 chain's last link — a contract-pack change, the CRP applied-defaults carry no per-agent LLM knobs today); the two shakeouts and the #924 budget re-read (§6.1 criteria 1–2, after this merges and deploys).

## Closes

Refs #927 — remaining: the CRP-level override (contract-pack change), and #410's read half stays its own issue.

## Evidence

- `run_regression_tests.sh`: **8,174 passed**, all gates (ruff check, format, test-quality lint, pytest). 50 new tests: adapter mappings, conformance for both adapters, the policy coverage guard, the chain at the base/repair/roles-handler/develop-qa-builder seams, profile validation, the telemetry field.
- **Live mechanism check through the new port**, host Ollama 0.32.14, `qwen3.6:27b`, a three-slot fill brief, `max_tokens=2500`:

  | level | completion tokens | wall | fences | response |
  |---|---|---|---|---|
  | `none` | **256** | 30.6 s | 3/3 | 922 chars, complete |
  | `high` | **2,500** (the cap) | 206.7 s | 0/3 | **empty** |

  The #924 failure shape, reproduced: with the channel on, the fill exhausts its budget thinking and emits nothing. Same adapter, same prompt, one kwarg.
- **The clamp's premise, measured**: `qwen2.5:7b` with `think: true` → `400 "qwen2.5:7b does not support thinking"`; with `think: false` → 200. Sending nothing for a channel-less model is correct; the wording in code now states exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbzZWzB8VgjZdbtKX9N41L
