### PR TITLE
feat(config): the LLM provider is required configuration — selected by name through the factory at both composition roots (#1157)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,9 +57,11 @@ SQUADOPS_PROFILE=dev  # Options: dev, local, lab, cloud
 # SQUADOPS__PREFECT__API__URL=http://prefect-server:4200/api
 
 # LLM Configuration
+# The provider is REQUIRED — it selects the adapter (ollama | vllm) and nothing defaults
+# it (#1157). docker-compose.yml sets it per service; set it here for host-side runs.
+SQUADOPS__LLM__PROVIDER=ollama
 # SQUADOPS__LLM__URL=http://localhost:11434
 # SQUADOPS__LLM__MODEL=llama3.1:8b
-# SQUADOPS__LLM__USE__LOCAL=true
 # SQUADOPS__LLM__TIMEOUT=60
 
 # Agent Configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to SquadOps are recorded here. Format loosely follows
 
 **1.7.0 — the Reasoning line opens.** Plan: `docs/plans/1-7-0-plan.md` (rev 3).
 
+### Changed — the LLM provider is required configuration (#1157, SIP-0106 Ruling 3)
+- **`SQUADOPS__LLM__PROVIDER` is required and never defaulted.** Two adapters were in the
+  tree while the factory defaulted `provider="ollama"`, the agent entrypoint never passed
+  one and `LLMConfig` had no field — the vLLM adapter was unreachable by any configuration
+  since it landed. Now `LLMConfig.provider` and `create_llm_provider(provider, …)` have no
+  default; a missing value fails at config load the way an unknown one fails in the
+  factory. Every deploy surface writes the value: the eight SquadOps service blocks in
+  `docker-compose.yml`, `.env.example` (uncommented), the test fixtures. The switch to
+  another provider is one PR changing that value (SIP-0106 §5).
+- **Both composition roots go through the factory**: the runtime-api no longer constructs
+  `OllamaAdapter` directly (the LLM half of #301), and the cycle-create model preflight asks
+  the port for `MODEL_LISTING` instead of `isinstance(OllamaAdapter)` — on any other
+  provider it was silently unverifiable.
+- The mis-nested `SQUADOPS__LLM__USE__LOCAL` example and the `use_local` field it never
+  reached are gone.
+
 ### Added — reasoning is a level on the port (#927)
 - **The port carries `reasoning: none | low | medium | high`**, never a provider's
   switch. Ollama maps `none → think:false` and any graded level → `think:true`; vLLM

--- a/adapters/llm/factory.py
+++ b/adapters/llm/factory.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 def create_llm_provider(
-    provider: str = "ollama",
+    provider: str,
     secret_manager: SecretManager | None = None,
     base_url: str = "http://localhost:11434",
     default_model: str = "llama3.2",
@@ -27,7 +27,9 @@ def create_llm_provider(
     """Create an LLM provider.
 
     Args:
-        provider: Provider name ("ollama" or "vllm")
+        provider: Provider name ("ollama" or "vllm"). Required — no default (#1157):
+            the factory's own rule below refuses an unknown name, and a *missing*
+            one used to fall back to Ollama the same silent way.
         secret_manager: Optional secret manager for resolving secret:// refs
         base_url: Base URL for the LLM server (may be secret:// ref)
         default_model: Default model to use

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,6 +189,7 @@ services:
       # LLM (SIP-0066: cycle task handlers)
       SQUADOPS__LLM__MODEL: "llama3.1:8b"
       SQUADOPS__LLM__TIMEOUT: ${SQUADOPS__LLM__TIMEOUT:-180}
+      SQUADOPS__LLM__PROVIDER: ollama  # required, never defaulted (#1157); the switch PR changes it (SIP-0106 §5)
       # Duty-transition scheduler (SIP-0089 §2.4). runtime-api is the single
       # central writer of agent mode (D16) — keep this enabled on exactly one
       # runtime-api instance (no leader election yet).
@@ -246,6 +247,7 @@ services:
       SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_ID: squadops-agent
       SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_SECRET: secret://agent_client_secret
       SQUADOPS__LLM__TIMEOUT: ${SQUADOPS__LLM__TIMEOUT:-180}
+      SQUADOPS__LLM__PROVIDER: ollama  # required, never defaulted (#1157); the switch PR changes it (SIP-0106 §5)
     volumes:
       - max_memory_data:/app/data/memory_db
     depends_on:
@@ -300,6 +302,7 @@ services:
       SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_ID: squadops-agent
       SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_SECRET: secret://agent_client_secret
       SQUADOPS__LLM__TIMEOUT: ${SQUADOPS__LLM__TIMEOUT:-180}
+      SQUADOPS__LLM__PROVIDER: ollama  # required, never defaulted (#1157); the switch PR changes it (SIP-0106 §5)
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -373,6 +376,7 @@ services:
       SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_ID: squadops-agent
       SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_SECRET: secret://agent_client_secret
       SQUADOPS__LLM__TIMEOUT: ${SQUADOPS__LLM__TIMEOUT:-180}
+      SQUADOPS__LLM__PROVIDER: ollama  # required, never defaulted (#1157); the switch PR changes it (SIP-0106 §5)
     volumes:
       - ./docker-compose.yml:/app/docker-compose.yml
       - /var/run/docker.sock:/var/run/docker.sock
@@ -429,6 +433,7 @@ services:
       SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_ID: squadops-agent
       SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_SECRET: secret://agent_client_secret
       SQUADOPS__LLM__TIMEOUT: ${SQUADOPS__LLM__TIMEOUT:-180}
+      SQUADOPS__LLM__PROVIDER: ollama  # required, never defaulted (#1157); the switch PR changes it (SIP-0106 §5)
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -481,6 +486,7 @@ services:
       SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_ID: squadops-agent
       SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_SECRET: secret://agent_client_secret
       SQUADOPS__LLM__TIMEOUT: ${SQUADOPS__LLM__TIMEOUT:-180}
+      SQUADOPS__LLM__PROVIDER: ollama  # required, never defaulted (#1157); the switch PR changes it (SIP-0106 §5)
     volumes:
       - data_memory_data:/app/data/memory_db
     depends_on:
@@ -537,6 +543,7 @@ services:
       SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_ID: squadops-agent
       SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_SECRET: secret://agent_client_secret
       SQUADOPS__LLM__TIMEOUT: ${SQUADOPS__LLM__TIMEOUT:-180}
+      SQUADOPS__LLM__PROVIDER: ollama  # required, never defaulted (#1157); the switch PR changes it (SIP-0106 §5)
     volumes:
       - bob_memory_data:/app/data/memory_db
     depends_on:
@@ -595,6 +602,7 @@ services:
       SQUADOPS_AGENT_ROLE: comms
       SQUADOPS_PROFILE: "${SQUADOPS_PROFILE:?Run bootstrap first}"
       SQUADOPS__SECRETS__PROVIDER: docker_secret
+      SQUADOPS__LLM__PROVIDER: ollama  # required, never defaulted (#1157)
       SQUADOPS__DB__URL: postgresql://squadops:secret://db_password@postgres:5432/squadops
       SQUADOPS__COMMS__RABBITMQ__URL: amqp://squadops:secret://rabbitmq_password@rabbitmq:5672/
       SQUADOPS__COMMS__REDIS__URL: redis://redis:6379/0

--- a/src/squadops/agents/entrypoint.py
+++ b/src/squadops/agents/entrypoint.py
@@ -360,6 +360,7 @@ class AgentRunner:
             )
         logger.info(f"Using LLM model: {llm_model}", extra={"agent_id": self.agent_id})
         llm = create_llm_provider(
+            provider=config.llm.provider,
             base_url=config.llm.url,
             default_model=llm_model,
             timeout_seconds=config.llm.timeout,

--- a/src/squadops/api/routes/cycles/cycles.py
+++ b/src/squadops/api/routes/cycles/cycles.py
@@ -51,23 +51,26 @@ router = APIRouter(prefix="/api/v1/projects/{project_id}/cycles", tags=["cycles"
 async def _pulled_model_names() -> list[str] | None:
     """Best-effort list of the LLM backend's pulled-model names, or ``None``.
 
-    ``None`` (backend not configured / not an Ollama adapter / unreachable) makes the
-    model-availability preflight *warn and allow* rather than block — never block on
+    ``None`` (backend not configured / provider declares no listing / unreachable) makes
+    the model-availability preflight *warn and allow* rather than block — never block on
     missing evidence (SIP-0095 §6.2). Only a reachable backend yields a verifiable list.
+
+    Asks the port what it can do (``LLMCapability.MODEL_LISTING``) rather than which
+    adapter class it is — SIP-0106 §3.2's site 2; the ``isinstance(OllamaAdapter)`` it
+    replaces made every non-Ollama provider silently unverifiable (#1157).
     """
     from squadops.api.runtime.deps import get_llm_port
+    from squadops.ports.llm.provider import LLMCapability
 
     try:
-        from adapters.llm.ollama import OllamaAdapter
-
         port = get_llm_port()
-        if not isinstance(port, OllamaAdapter):
+        if not port.supports(LLMCapability.MODEL_LISTING):
             return None
-        raw = await port.list_pulled_models()
-    except Exception as exc:  # not configured, wrong adapter, or backend unreachable
+        raw = await port.list_available_models()
+    except Exception as exc:  # not configured or backend unreachable
         logger.info("preflight_model_list_unverifiable", extra={"error": str(exc)})
         return None
-    return [name for m in raw if (name := m.get("name"))]
+    return [m.name for m in raw if m.name]
 
 
 async def _sandbox_preflight_decision() -> PreflightDecision:

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -429,16 +429,23 @@ async def _init_cycle_subsystem(config, pool) -> None:
     except Exception as e:
         logger.error(f"Failed to initialize cycle ports: {e}")
 
+    # #1157 (the LLM half of #301): the configured provider through the factory, never
+    # a directly constructed adapter. Construction is outside the try on purpose — an
+    # unknown provider name is a misconfiguration and must stop startup, while the
+    # registration below stays non-fatal.
+    from adapters.llm.factory import create_llm_provider
+
+    llm_adapter = create_llm_provider(
+        provider=config.llm.provider,
+        base_url=config.llm.url,
+        default_model=config.llm.model or "qwen2.5:7b",
+        timeout_seconds=float(config.llm.timeout),
+    )
     try:
-        from adapters.llm.ollama import OllamaAdapter
         from squadops.api.runtime.deps import set_llm_port
 
-        ollama_adapter = OllamaAdapter(
-            base_url=config.llm.url,
-            default_model=config.llm.model or "qwen2.5:7b",
-        )
-        set_llm_port(ollama_adapter)
-        logger.info("LLM port registered for model management")
+        set_llm_port(llm_adapter)
+        logger.info("LLM port registered for model management (provider=%s)", config.llm.provider)
     except Exception as e:
         logger.warning("LLM port not registered (non-fatal): %s", e)
 

--- a/src/squadops/config/schema.py
+++ b/src/squadops/config/schema.py
@@ -528,13 +528,22 @@ class PrefectConfig(BaseModel):
 
 
 class LLMConfig(BaseModel):
-    """LLM provider configuration."""
+    """LLM provider configuration.
 
+    ``provider`` is **required** (#1157, SIP-0106 Ruling 3): a selector at a
+    composition seam is never defaulted. Two adapters were in the tree while the
+    factory silently returned Ollama for every caller — a missing value must fail
+    at config load exactly as a misspelt one fails in the factory. Every deploy
+    surface writes ``SQUADOPS__LLM__PROVIDER`` explicitly; nothing infers it.
+    """
+
+    provider: str = Field(
+        description="LLM provider selecting the adapter: 'ollama' or 'vllm' (required)"
+    )
     url: str = Field(
         default="http://host.docker.internal:11434", description="LLM API URL (Ollama)"
     )
     model: str | None = Field(default=None, description="Default LLM model name")
-    use_local: bool = Field(default=True, description="Use local LLM provider")
     timeout: int = Field(default=180, ge=1, description="LLM request timeout in seconds")
 
 
@@ -755,7 +764,7 @@ class AppConfig(BaseModel):
     )
 
     # LLM
-    llm: LLMConfig = Field(default_factory=LLMConfig, description="LLM configuration")
+    llm: LLMConfig = Field(description="LLM configuration (required: it names the provider)")
 
     # Prompts (SIP-0084)
     prompts: PromptsConfig = Field(

--- a/tests/unit/api/test_scheduler_bootstrap.py
+++ b/tests/unit/api/test_scheduler_bootstrap.py
@@ -27,6 +27,7 @@ from squadops.config.schema import (
     AuthConfig,
     CommsConfig,
     DBConfig,
+    LLMConfig,
     RabbitMQConfig,
     RedisConfig,
 )
@@ -44,6 +45,7 @@ def _config(*, enabled: bool, poll: int = 30) -> AppConfig:
             redis=RedisConfig(url="redis://localhost:6379/0"),
         ),
         auth=AuthConfig(enabled=False),
+        llm=LLMConfig(provider="ollama"),
         runtime={"scheduler": {"enabled": enabled, "poll_interval_seconds": poll}},
     )
 

--- a/tests/unit/cli/test_integration.py
+++ b/tests/unit/cli/test_integration.py
@@ -50,6 +50,7 @@ _TEST_ENV = {
     "SQUADOPS__DB__URL": "postgresql://test:test@localhost:5432/test",
     "SQUADOPS__COMMS__RABBITMQ__URL": "amqp://test:test@localhost:5672/",
     "SQUADOPS__COMMS__REDIS__URL": "redis://localhost:6379/0",
+    "SQUADOPS__LLM__PROVIDER": "ollama",  # required (#1157): the app loads config at import
 }
 
 

--- a/tests/unit/config/test_llm_provider_required.py
+++ b/tests/unit/config/test_llm_provider_required.py
@@ -1,0 +1,62 @@
+"""``llm.provider`` is required configuration (#1157, SIP-0106 Ruling 3).
+
+A selector at a composition seam is never defaulted: with the old ``default_factory``
+an ``AppConfig`` built with no LLM section at all quietly ran Ollama, and
+``SQUADOPS__LLM__PROVIDER`` did not exist as a key.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from squadops.config.loader import _parse_env_overrides
+from squadops.config.schema import (
+    AppConfig,
+    AuthConfig,
+    CommsConfig,
+    DBConfig,
+    LLMConfig,
+    RabbitMQConfig,
+    RedisConfig,
+)
+
+pytestmark = [pytest.mark.domain_contracts]
+
+
+def _rest() -> dict:
+    return {
+        "db": DBConfig(url="postgresql://u@localhost:5432/db"),
+        "comms": CommsConfig(
+            rabbitmq=RabbitMQConfig(url="amqp://u@localhost:5672/"),
+            redis=RedisConfig(url="redis://localhost:6379/0"),
+        ),
+        "auth": AuthConfig(enabled=False),
+    }
+
+
+def test_llm_config_without_a_provider_fails_to_validate():
+    with pytest.raises(ValidationError) as exc:
+        LLMConfig()  # type: ignore[call-arg]
+    assert "provider" in str(exc.value)
+
+
+def test_app_config_without_an_llm_section_fails_rather_than_defaulting():
+    with pytest.raises(ValidationError) as exc:
+        AppConfig(**_rest())
+    assert "llm" in str(exc.value)
+
+
+def test_the_provider_is_carried_through_and_other_llm_fields_keep_defaults():
+    cfg = AppConfig(**_rest(), llm=LLMConfig(provider="vllm"))
+    assert cfg.llm.provider == "vllm"
+    assert cfg.llm.timeout == 180  # only the selector is required
+
+
+def test_env_var_reaches_the_llm_provider_field(monkeypatch):
+    """``SQUADOPS__LLM__PROVIDER`` nests as ``llm.provider`` — the key a deploy
+    surface writes is the key the schema reads. (The old ``SQUADOPS__LLM__USE__LOCAL``
+    in ``.env.example`` nested as ``llm.use.local`` and reached nothing.)"""
+    monkeypatch.setenv("SQUADOPS__LLM__PROVIDER", "vllm")
+    overrides = _parse_env_overrides()
+    assert overrides["llm"]["provider"] == "vllm"

--- a/tests/unit/cycles/test_model_preflight_port.py
+++ b/tests/unit/cycles/test_model_preflight_port.py
@@ -1,0 +1,55 @@
+"""The cycle-create model preflight asks the port, not the adapter class (#1157, SIP-0106 §3.2).
+
+Bug: ``isinstance(port, OllamaAdapter)`` returned ``None`` — "unverifiable, warn and
+allow" — for every other provider, so on vLLM or Atlas a profile naming an absent model
+was never caught before dispatch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.api.routes.cycles.cycles import _pulled_model_names
+from squadops.api.runtime import deps
+from squadops.llm.models import ModelInfo
+from squadops.ports.llm.provider import LLMCapability
+
+pytestmark = [pytest.mark.domain_api]
+
+
+class _Port:
+    def __init__(self, *, listing: bool, models=None, fail=False):
+        self._listing, self._models, self._fail = listing, models or [], fail
+
+    def supports(self, capability: str) -> bool:
+        return capability == LLMCapability.MODEL_LISTING and self._listing
+
+    async def list_available_models(self):
+        if self._fail:
+            raise ConnectionError("backend down")
+        return self._models
+
+
+@pytest.fixture(autouse=True)
+def _restore_port():
+    before = deps._llm_port
+    yield
+    deps._llm_port = before
+
+
+async def test_any_provider_declaring_listing_is_verified():
+    deps.set_llm_port(
+        _Port(listing=True, models=[ModelInfo(name="qwen3.8:27b"), ModelInfo(name="")])
+    )
+    assert await _pulled_model_names() == ["qwen3.8:27b"]
+
+
+async def test_a_provider_without_listing_is_unverifiable_not_empty():
+    """``None`` warns-and-allows; ``[]`` would read as *no models present* and block."""
+    deps.set_llm_port(_Port(listing=False))
+    assert await _pulled_model_names() is None
+
+
+async def test_an_unreachable_backend_is_unverifiable():
+    deps.set_llm_port(_Port(listing=True, fail=True))
+    assert await _pulled_model_names() is None

--- a/tests/unit/llm/test_factory.py
+++ b/tests/unit/llm/test_factory.py
@@ -1,0 +1,44 @@
+"""The LLM factory selects by name and nothing else (#1157, SIP-0106 §3.1).
+
+The bug this file exists for: two adapters in the tree and no caller able to reach the
+second, because the factory defaulted ``provider="ollama"`` and every composition root
+omitted it. A missing selector must fail the way an unknown one does.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from adapters.llm.factory import create_llm_provider
+from adapters.llm.ollama import OllamaAdapter
+from adapters.llm.vllm import VLLMAdapter
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+
+def test_a_missing_provider_is_an_error_not_ollama():
+    with pytest.raises(TypeError, match="provider"):
+        create_llm_provider(base_url="http://x:1", default_model="m")  # type: ignore[call-arg]
+
+
+@pytest.mark.parametrize(
+    ("name", "cls"),
+    [("ollama", OllamaAdapter), ("vllm", VLLMAdapter)],
+)
+def test_each_registered_name_resolves_its_own_adapter(name, cls):
+    adapter = create_llm_provider(provider=name, base_url="http://x:1", default_model="m")
+    assert type(adapter) is cls
+
+
+def test_vllm_receives_its_api_key():
+    """The one provider-specific kwarg the factory forwards; dropped, a bearer-gated
+    server (Atlas is one) answers 401 to every call."""
+    adapter = create_llm_provider(
+        provider="vllm", base_url="http://x:1", default_model="m", api_key="tok"
+    )
+    assert adapter._api_key == "tok"
+
+
+def test_an_unknown_name_raises_and_never_falls_back():
+    with pytest.raises(ValueError, match="Unknown LLM provider: olama"):
+        create_llm_provider(provider="olama", base_url="http://x:1", default_model="m")

--- a/tests/unit/runtime/test_scheduler_config.py
+++ b/tests/unit/runtime/test_scheduler_config.py
@@ -19,6 +19,7 @@ from squadops.config.schema import (
     AuthConfig,
     CommsConfig,
     DBConfig,
+    LLMConfig,
     RabbitMQConfig,
     RedisConfig,
     SchedulerConfig,
@@ -36,6 +37,7 @@ def _app_config(runtime: dict | None = None) -> AppConfig:
             redis=RedisConfig(url="redis://localhost:6379/0"),
         ),
         "auth": AuthConfig(enabled=False),
+        "llm": LLMConfig(provider="ollama"),
     }
     if runtime is not None:
         kwargs["runtime"] = runtime


### PR DESCRIPTION
## What

SIP-0106's P2, built to the owner's Ruling 3: **required, never defaulted.** Two adapters were in the tree and no configuration could select the second — the factory defaulted `provider="ollama"` (`adapters/llm/factory.py`), the agent entrypoint never passed one, and `LLMConfig` had no field, so `SQUADOPS__LLM__PROVIDER` did nothing, silently.

- **`LLMConfig.provider: str`** with no default, and **`AppConfig.llm`** without its `default_factory` — a config without the provider fails validation at load (`llm: Field required` / `llm.provider: Field required`), the same class of failure as a misspelt name in the factory. Only the selector is required; `url`/`model`/`timeout` keep their defaults.
- **`create_llm_provider(provider, …)`** — no default. The `Unknown LLM provider` refusal stays.
- **Both composition roots through the factory**: the agent entrypoint passes `provider=config.llm.provider`; the runtime-api builds its LLM port with `create_llm_provider` instead of constructing `OllamaAdapter` directly (the LLM half of #301). Construction is outside the non-fatal `try` so an unknown name stops startup.
- **Site 5**: the cycle-create model preflight asks `port.supports(MODEL_LISTING)` and calls `list_available_models()` instead of `isinstance(port, OllamaAdapter)` — every non-Ollama provider was silently "unverifiable, warn and allow".
- **Every deploy surface writes the value** — `docker-compose.yml`: the seven agent blocks (after `SQUADOPS__LLM__TIMEOUT`) plus `joi`, as a **literal `ollama`**, not a `${…:-ollama}` default; `.env.example` uncommented; the two `AppConfig`-building tests; the CLI integration fixture (the runtime-api app loads config at import). **`docker-compose.yml` is modified deliberately** — the issue's fix shape, endorsed 2026-08-28; no service or container names change.
- The mis-nested `SQUADOPS__LLM__USE__LOCAL` example (nested as `llm.use.local`) and the `use_local` field nothing read are removed.

**Not here:** the Atlas adapter itself (#1159) and the queue-factory half of #301.

## Closes

Closes #1157
Refs #301 — remaining: the queue-factory half and the composition-root design note.
Refs #154 — remaining: the other three domain→adapter sites and the all-packages import guard.

## Evidence

`run_regression_tests.sh`: **8,187 passed**, all gates. New tests: `tests/unit/llm/test_factory.py` (missing provider is a `TypeError`, each name resolves its own class, vLLM receives `api_key`, unknown raises), `tests/unit/config/test_llm_provider_required.py` (`LLMConfig()` and `AppConfig` without `llm` fail; the env var nests to `llm.provider`), `tests/unit/cycles/test_model_preflight_port.py` (listing-declaring provider verified; non-listing → `None` not `[]`; unreachable → `None`). The first regression run caught the CLI integration fixture importing the app without the var — five setup errors — which is the guard working as intended; the fixture now sets it.

**Deploy note:** after merge, `rebuild_and_deploy.sh runtime-api agents` — the compose file carries the value, so no `.env` change is needed on the Spark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbzZWzB8VgjZdbtKX9N41L
