### PR TITLE
feat(llm): Atlas adapter — the DGX Spark engine behind LLMPort, from the measured dialect (#1159, SIP-0106 P4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,9 @@ SQUADOPS_PROFILE=dev  # Options: dev, local, lab, cloud
 # it (#1157). docker-compose.yml sets it per service; set it here for host-side runs.
 SQUADOPS__LLM__PROVIDER=ollama
 # SQUADOPS__LLM__URL=http://localhost:11434
+# Atlas (provider=atlas, port 8888) requires a bearer token once bound off localhost; give
+# it as a secret:// reference resolved by the configured secrets provider (SIP-0106 §3.5).
+# SQUADOPS__LLM__API_KEY=secret://atlas_api_key
 # SQUADOPS__LLM__MODEL=llama3.1:8b
 # SQUADOPS__LLM__TIMEOUT=60
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ All notable changes to SquadOps are recorded here. Format loosely follows
 - The mis-nested `SQUADOPS__LLM__USE__LOCAL` example and the `use_local` field it never
   reached are gone.
 
+### Added — the Atlas adapter (#1159, SIP-0106 P4)
+- **`adapters/llm/atlas.py`**, selected by `SQUADOPS__LLM__PROVIDER=atlas`: its own file,
+  not a subclass of the vLLM adapter (SIP-0106 §3.5a), because the dialect diverges where
+  it matters — every item measured on the Spark on 2026-08-28. A bearer token is mandatory
+  once the server is bound off localhost (`SQUADOPS__LLM__API_KEY`, a `secret://` ref the
+  loader resolves; a 401 names that setting rather than reporting a network failure); the
+  engine's own `response_token/s` is reported instead of a wall-clock derivation;
+  `reasoning_tokens` are counted separately (`thinking_tokens: True`); the port's level
+  maps onto Atlas's `reasoning_effort` ladder verbatim except `high → xhigh`, which the
+  served Qwen3.8 template requires; streamed `reasoning_content` deltas never reach the
+  text. Registered as the conformance suite's third case, with the measured shapes.
+- `ChatMessage` / `LLMResponse` gain `reasoning_tokens` (None when not reported, never
+  zero); `Qwen/Qwen3.8-27B-FP8` joins the model registry with the served 32K window.
+
 ### Added — reasoning is a level on the port (#927)
 - **The port carries `reasoning: none | low | medium | high`**, never a provider's
   switch. Ollama maps `none → think:false` and any graded level → `think:true`; vLLM

--- a/adapters/llm/__init__.py
+++ b/adapters/llm/__init__.py
@@ -3,15 +3,18 @@
 Provides implementations of LLM ports:
 - OllamaAdapter: Local Ollama LLM server adapter
 - VLLMAdapter: vLLM OpenAI-compatible server adapter
+- AtlasAdapter: Atlas (DGX Spark inference engine) adapter, SIP-0106
 
 Part of SIP-0.8.7 Infrastructure Ports Migration.
 """
 
+from adapters.llm.atlas import AtlasAdapter
 from adapters.llm.factory import create_llm_provider
 from adapters.llm.ollama import OllamaAdapter
 from adapters.llm.vllm import VLLMAdapter
 
 __all__ = [
+    "AtlasAdapter",
     "OllamaAdapter",
     "VLLMAdapter",
     "create_llm_provider",

--- a/adapters/llm/atlas.py
+++ b/adapters/llm/atlas.py
@@ -1,0 +1,438 @@
+"""Atlas LLM adapter — the DGX Spark inference engine behind ``LLMPort``.
+
+Second OpenAI-shaped adapter, per the Atlas Provider Adapter SIP (SIP-0106) P4 — its
+own file rather than a subclass of the vLLM one (§3.5a: one adapter per provider),
+because the dialect diverges where it matters and a shared base would need provider
+conditionals (#559). Everything below is from the 2026-08-28 session on the Spark
+(`avarok/atlas-gb10` serving `Qwen/Qwen3.8-27B-FP8`; #1158 carries the record):
+
+- **Auth is mandatory** once the server is bound off localhost: a bearer token from
+  ``--auth-tokens-file``; no or wrong token → 401. The adapter takes ``api_key`` and
+  turns a 401 into an error that names the setting, not a generic connection failure.
+- **Usage is richer than OpenAI's**: ``completion_tokens_details.reasoning_tokens``
+  (thinking accounted separately — ``thinking_tokens: True``), ``time_to_first_token_ms``
+  and the engine's own ``response_token/s``. So, unlike the vLLM adapter, tokens/sec is
+  **not** derived from wall-clock; the engine's decode rate is reported as-is, with the
+  wall-clock derivation only as a fallback when the field is absent.
+- **Reasoning is a server-side ladder**: ``reasoning_effort`` with a real ``none``. The
+  port's ``none|low|medium`` pass through; ``high`` maps to ``xhigh``, because the
+  Qwen3.8 chat template accepts only ``low|medium|xhigh`` and answers ``high`` with a
+  400 (measured; ``xhigh`` is the template's top tier). Thinking arrives as a separate
+  ``message.reasoning_content`` / ``delta.reasoning_content`` — never inline — and the
+  streaming path must not splice those deltas into the text.
+- **Streaming**: SSE ``data: {json}`` frames, ``data: [DONE]``; with
+  ``stream_options.include_usage`` the usage rides a frame with ``choices: []``.
+- **No model management over HTTP** (405/404); weights are ``hf download``ed and fixed
+  at ``serve`` (``--no-auto-swap``). ``/v1/models`` entries carry ``max_model_len``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+
+from squadops.llm.exceptions import (
+    LLMConnectionError,
+    LLMModelNotFoundError,
+    LLMTimeoutError,
+)
+from squadops.llm.models import ChatMessage, LLMRequest, LLMResponse, ModelInfo, ReasoningLevel
+from squadops.ports.llm.provider import LLMCapability, LLMPort
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MODEL_LIST_TIMEOUT = 10.0
+
+#: The port's level → Atlas's ``reasoning_effort``. Verbatim except ``high``, which the
+#: served template rejects; ``xhigh`` is its top tier (SIP-0106 §10.2 fact 6).
+_REASONING_EFFORT: dict[str, str] = {
+    ReasoningLevel.NONE: "none",
+    ReasoningLevel.LOW: "low",
+    ReasoningLevel.MEDIUM: "medium",
+    ReasoningLevel.HIGH: "xhigh",
+}
+
+
+def _usage_from(payload: dict[str, Any]) -> tuple[int | None, int | None, int | None, int | None]:
+    """(prompt, completion, total, reasoning) from Atlas's ``usage`` object.
+
+    All-or-nothing on the three OpenAI counts (a partial row is worse than none —
+    SIP-0106 §3.5); ``reasoning`` is ``None`` when the details block is absent, never
+    zero-filled, so "not reported" stays distinguishable from "did not think".
+    """
+    usage = payload.get("usage") or {}
+    prompt = usage.get("prompt_tokens")
+    completion = usage.get("completion_tokens")
+    total = usage.get("total_tokens")
+    if total is None and (prompt is not None or completion is not None):
+        total = (prompt or 0) + (completion or 0)
+    reasoning = (usage.get("completion_tokens_details") or {}).get("reasoning_tokens")
+    return prompt, completion, total, reasoning
+
+
+def _tokens_per_second(
+    payload: dict[str, Any], completion: int | None, elapsed: float
+) -> float | None:
+    """The engine's own decode rate when reported; wall-clock only as a fallback.
+
+    ``response_token/s`` is Atlas's measurement of its decode phase. The fallback is
+    inclusive of prefill and queueing (the vLLM adapter's number) and is marked as such
+    in the log, so the two are never averaged as if they were the same quantity.
+    """
+    native = (payload.get("usage") or {}).get("response_token/s")
+    if isinstance(native, (int, float)) and native > 0:
+        return round(float(native), 2)
+    if not completion or elapsed <= 0:
+        return None
+    return round(completion / elapsed, 2)
+
+
+class AtlasAdapter(LLMPort):
+    """Atlas adapter speaking its OpenAI-compatible surface on ``:8888``.
+
+    Provider string ``"atlas"``.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://host.docker.internal:8888",
+        default_model: str = "",
+        timeout_seconds: float = 180.0,
+        model_list_timeout_seconds: float = _DEFAULT_MODEL_LIST_TIMEOUT,
+        api_key: str | None = None,
+    ):
+        """
+        Args:
+            base_url: server root (``http://host:8888``); ``/v1`` is appended by the paths.
+            default_model: the HuggingFace id Atlas was started with, verbatim
+                (``Qwen/Qwen3.8-27B-FP8``) — it is echoed in every response.
+            timeout_seconds: default generation timeout.
+            model_list_timeout_seconds: timeout for listing/health, separate from generation.
+            api_key: the bearer token. Mandatory on a server bound off localhost; resolved
+                config carries it as a ``secret://`` ref the loader resolves before it
+                reaches the factory.
+        """
+        self._base_url = base_url.rstrip("/")
+        self._default_model = default_model
+        self._timeout = timeout_seconds
+        self._model_list_timeout = model_list_timeout_seconds
+        self._api_key = api_key
+        self._models_cache: list[str] = []
+        self._client: httpx.AsyncClient | None = None
+
+    @property
+    def default_model(self) -> str:
+        return self._default_model
+
+    def capabilities(self) -> dict[str, bool]:
+        """Declared from what the live server did on 2026-08-28, not from its docs."""
+        return {
+            LLMCapability.MODEL_LISTING: True,
+            LLMCapability.MODEL_MANAGEMENT: False,  # 405/404 over HTTP; fixed at `serve`
+            LLMCapability.STREAMING_USAGE: True,  # usage frame with `choices: []`
+            LLMCapability.THINKING_TOKENS: True,  # `completion_tokens_details.reasoning_tokens`
+            LLMCapability.REASONING_CONTROL: True,  # `reasoning_effort`, incl. `none`
+        }
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            headers = {"Authorization": f"Bearer {self._api_key}"} if self._api_key else {}
+            self._client = httpx.AsyncClient(
+                base_url=self._base_url, timeout=httpx.Timeout(self._timeout), headers=headers
+            )
+        return self._client
+
+    def _payload(
+        self,
+        messages: list[ChatMessage],
+        model: str,
+        max_tokens: int | None,
+        temperature: float | None,
+        reasoning: str | None = None,
+        *,
+        stream: bool = False,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": m.role, "content": m.content} for m in messages],
+            "stream": stream,
+        }
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        if temperature is not None:
+            payload["temperature"] = temperature
+        if reasoning is not None:
+            payload["reasoning_effort"] = _REASONING_EFFORT.get(reasoning, reasoning)
+        if stream:
+            payload["stream_options"] = {"include_usage": True}
+        return payload
+
+    def _translate(self, exc: Exception, model: str, operation: str) -> Exception:
+        """Map a transport failure onto the port's exception vocabulary.
+
+        Load-bearing (#568): the correction loop classifies failure locus from these.
+        A 401 is named for what it is — the bearer token — because the generic
+        "connection failed" it would otherwise become sends an operator to the network.
+        """
+        if isinstance(exc, httpx.TimeoutException):
+            return LLMTimeoutError(f"Atlas {operation} timed out after {self._timeout}s")
+        if isinstance(exc, httpx.ConnectError):
+            return LLMConnectionError(f"Failed to connect to Atlas at {self._base_url}")
+        if isinstance(exc, httpx.HTTPStatusError):
+            status = exc.response.status_code
+            if status == 401:
+                return LLMConnectionError(
+                    "Atlas rejected the bearer token (401): set SQUADOPS__LLM__API_KEY to a "
+                    "token from the server's --auth-tokens-file"
+                )
+            if status == 404:
+                return LLMModelNotFoundError(f"Model '{model}' not found on Atlas")
+            detail = exc.response.text[:200]
+            return LLMConnectionError(f"Atlas {operation} failed ({status}): {detail}")
+        return LLMConnectionError(f"Atlas {operation} failed: {exc}")
+
+    async def generate(self, request: LLMRequest) -> LLMResponse:
+        """A bare prompt as a single-user-turn chat completion (``/v1/completions`` is
+        not universal on OpenAI-shaped backends; ``/v1/chat/completions`` is)."""
+        model = request.model or self._default_model
+        message = await self._chat(
+            [ChatMessage(role="user", content=request.prompt)],
+            model=model,
+            max_tokens=request.max_tokens,
+            temperature=request.temperature,
+            timeout_seconds=request.timeout_seconds,
+            reasoning=request.reasoning,
+            operation="generate",
+        )
+        return LLMResponse(
+            text=message.content,
+            model=model,
+            prompt_tokens=message.prompt_tokens,
+            completion_tokens=message.completion_tokens,
+            total_tokens=message.total_tokens,
+            tokens_per_second=message.tokens_per_second,
+            reasoning_tokens=message.reasoning_tokens,
+        )
+
+    async def chat(
+        self,
+        messages: list[ChatMessage],
+        model: str | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        timeout_seconds: float | None = None,
+        reasoning: str | None = None,
+    ) -> ChatMessage:
+        return await self._chat(
+            messages,
+            model=model or self._default_model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            timeout_seconds=timeout_seconds,
+            reasoning=reasoning,
+            operation="chat",
+        )
+
+    async def _chat(
+        self,
+        messages: list[ChatMessage],
+        *,
+        model: str,
+        max_tokens: int | None,
+        temperature: float | None,
+        timeout_seconds: float | None,
+        reasoning: str | None,
+        operation: str,
+    ) -> ChatMessage:
+        client = await self._get_client()
+        timeout = timeout_seconds or self._timeout
+        started = time.monotonic()
+        try:
+            response = await client.post(
+                "/v1/chat/completions",
+                json=self._payload(messages, model, max_tokens, temperature, reasoning),
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+        except Exception as e:
+            raise self._translate(e, model, operation) from e
+
+        elapsed = time.monotonic() - started
+        message = (data.get("choices") or [{}])[0].get("message") or {}
+        prompt_tok, completion_tok, total_tok, reasoning_tok = _usage_from(data)
+        tps = _tokens_per_second(data, completion_tok, elapsed)
+        logger.info(
+            "LLM %s completed: model=%s, prompt_tokens=%s, completion_tokens=%s, "
+            "reasoning_tokens=%s, t/s=%.1f",
+            operation,
+            model,
+            prompt_tok,
+            completion_tok,
+            reasoning_tok,
+            tps or 0.0,
+        )
+        return ChatMessage(
+            role=message.get("role", "assistant"),
+            content=message.get("content", "") or "",
+            prompt_tokens=prompt_tok,
+            completion_tokens=completion_tok,
+            total_tokens=total_tok,
+            tokens_per_second=tps,
+            reasoning_tokens=reasoning_tok,
+        )
+
+    async def _stream_frames(
+        self,
+        messages: list[ChatMessage],
+        model: str,
+        max_tokens: int | None,
+        temperature: float | None,
+        timeout: float,
+        reasoning: str | None,
+        operation: str,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Decoded SSE frames up to the ``[DONE]`` sentinel; a malformed frame is skipped."""
+        client = await self._get_client()
+        try:
+            async with client.stream(
+                "POST",
+                "/v1/chat/completions",
+                json=self._payload(
+                    messages, model, max_tokens, temperature, reasoning, stream=True
+                ),
+                timeout=timeout,
+            ) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line.startswith("data:"):
+                        continue
+                    raw = line[5:].strip()
+                    if raw == "[DONE]":
+                        break
+                    try:
+                        yield json.loads(raw)
+                    except json.JSONDecodeError:
+                        logger.debug("Skipping malformed Atlas SSE frame")
+        except (httpx.TimeoutException, httpx.ConnectError, httpx.HTTPStatusError) as e:
+            raise self._translate(e, model, operation) from e
+
+    async def chat_stream(
+        self,
+        messages: list[ChatMessage],
+        model: str | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        timeout_seconds: float | None = None,
+        reasoning: str | None = None,
+    ) -> AsyncIterator[str]:
+        """Assistant *content* as text chunks. ``delta.reasoning_content`` frames are the
+        thinking channel and are not content — they are skipped, not spliced in."""
+        resolved = model or self._default_model
+        async for frame in self._stream_frames(
+            messages,
+            resolved,
+            max_tokens,
+            temperature,
+            timeout_seconds or self._timeout,
+            reasoning,
+            "chat_stream",
+        ):
+            for choice in frame.get("choices") or []:
+                content = (choice.get("delta") or {}).get("content")
+                if content:
+                    yield content
+
+    async def chat_stream_with_usage(
+        self,
+        messages: list[ChatMessage],
+        model: str | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        timeout_seconds: float | None = None,
+        reasoning: str | None = None,
+    ) -> ChatMessage:
+        """Stream for liveness, return one assembled message with the usage frame's counts."""
+        resolved = model or self._default_model
+        started = time.monotonic()
+        chunks: list[str] = []
+        usage_frame: dict[str, Any] = {}
+        async for frame in self._stream_frames(
+            messages,
+            resolved,
+            max_tokens,
+            temperature,
+            timeout_seconds or self._timeout,
+            reasoning,
+            "chat_stream_with_usage",
+        ):
+            for choice in frame.get("choices") or []:
+                content = (choice.get("delta") or {}).get("content")
+                if content:
+                    chunks.append(content)
+            if frame.get("usage"):
+                usage_frame = frame
+        elapsed = time.monotonic() - started
+        prompt_tok, completion_tok, total_tok, reasoning_tok = _usage_from(usage_frame)
+        tps = _tokens_per_second(usage_frame, completion_tok, elapsed)
+        return ChatMessage(
+            role="assistant",
+            content="".join(chunks),
+            prompt_tokens=prompt_tok,
+            completion_tokens=completion_tok,
+            total_tokens=total_tok,
+            tokens_per_second=tps,
+            reasoning_tokens=reasoning_tok,
+        )
+
+    def list_models(self) -> list[str]:
+        """Cached names; no I/O, per the port contract."""
+        return self._models_cache.copy()
+
+    async def refresh_models(self) -> list[str]:
+        """Refresh the cache, keeping the last known list on failure (an emptied cache
+        reads downstream as *no models present* and blocks work)."""
+        try:
+            self._models_cache = [m.name for m in await self.list_available_models()]
+        except Exception:
+            logger.debug("Atlas model refresh failed; keeping the last known list")
+        return self._models_cache.copy()
+
+    async def list_available_models(self) -> list[ModelInfo]:
+        """``/v1/models`` — ids verbatim (HF paths); no size or modification time, so
+        those stay ``None``. Atlas's extra ``max_model_len`` is the served window, not a
+        model fact, and is not surfaced here."""
+        client = await self._get_client()
+        try:
+            response = await client.get("/v1/models", timeout=self._model_list_timeout)
+            response.raise_for_status()
+            data = response.json()
+        except Exception as e:
+            raise self._translate(e, self._default_model, "list_available_models") from e
+        return [ModelInfo(name=name) for entry in data.get("data", []) if (name := entry.get("id"))]
+
+    async def health(self) -> dict[str, Any]:
+        """Reachability and auth in one probe; never raises."""
+        try:
+            client = await self._get_client()
+            response = await client.get("/v1/models", timeout=self._model_list_timeout)
+            report: dict[str, Any] = {
+                "healthy": response.status_code == 200,
+                "base_url": self._base_url,
+                "models_available": len(self._models_cache),
+            }
+            if response.status_code == 401:
+                report["error"] = "bearer token rejected (set SQUADOPS__LLM__API_KEY)"
+            return report
+        except Exception as e:
+            return {"healthy": False, "base_url": self._base_url, "error": str(e)}
+
+    async def close(self) -> None:
+        if self._client:
+            await self._client.aclose()
+            self._client = None

--- a/adapters/llm/factory.py
+++ b/adapters/llm/factory.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from adapters.llm.atlas import AtlasAdapter
 from adapters.llm.ollama import OllamaAdapter
 from adapters.llm.vllm import VLLMAdapter
 from squadops.ports.llm.provider import LLMPort
@@ -27,7 +28,7 @@ def create_llm_provider(
     """Create an LLM provider.
 
     Args:
-        provider: Provider name ("ollama" or "vllm"). Required — no default (#1157):
+        provider: Provider name ("ollama", "vllm" or "atlas"). Required — no default (#1157):
             the factory's own rule below refuses an unknown name, and a *missing*
             one used to fall back to Ollama the same silent way.
         secret_manager: Optional secret manager for resolving secret:// refs
@@ -55,6 +56,14 @@ def create_llm_provider(
 
     if provider == "vllm":
         return VLLMAdapter(
+            base_url=base_url,
+            default_model=default_model,
+            timeout_seconds=timeout_seconds,
+            api_key=config.get("api_key"),
+        )
+
+    if provider == "atlas":
+        return AtlasAdapter(
             base_url=base_url,
             default_model=default_model,
             timeout_seconds=timeout_seconds,

--- a/src/squadops/agents/entrypoint.py
+++ b/src/squadops/agents/entrypoint.py
@@ -364,6 +364,7 @@ class AgentRunner:
             base_url=config.llm.url,
             default_model=llm_model,
             timeout_seconds=config.llm.timeout,
+            api_key=config.llm.api_key,
         )
 
         # Create memory adapter

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -440,6 +440,7 @@ async def _init_cycle_subsystem(config, pool) -> None:
         base_url=config.llm.url,
         default_model=config.llm.model or "qwen2.5:7b",
         timeout_seconds=float(config.llm.timeout),
+        api_key=config.llm.api_key,
     )
     try:
         from squadops.api.runtime.deps import set_llm_port

--- a/src/squadops/config/schema.py
+++ b/src/squadops/config/schema.py
@@ -538,10 +538,17 @@ class LLMConfig(BaseModel):
     """
 
     provider: str = Field(
-        description="LLM provider selecting the adapter: 'ollama' or 'vllm' (required)"
+        description="LLM provider selecting the adapter: 'ollama', 'vllm' or 'atlas' (required)"
     )
     url: str = Field(
         default="http://host.docker.internal:11434", description="LLM API URL (Ollama)"
+    )
+    api_key: str | None = Field(
+        default=None,
+        description=(
+            "Bearer token for a provider that requires one (Atlas bound off localhost does; "
+            "Ollama does not). Write it as a secret:// reference — the loader resolves it."
+        ),
     )
     model: str | None = Field(default=None, description="Default LLM model name")
     timeout: int = Field(default=180, ge=1, description="LLM request timeout in seconds")

--- a/src/squadops/llm/model_registry.py
+++ b/src/squadops/llm/model_registry.py
@@ -89,6 +89,17 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         default_max_completion=8_192,
         reasoning_control=ReasoningControl.TOGGLE,
     ),
+    # Atlas serves models by HuggingFace path, so the same weights carry a second name
+    # (SIP-0106 §3.4 — model identity is provider-scoped). The window is the one the
+    # local-spark recipe serves (`--max-seq-len 32768`, #1158), not the checkpoint's
+    # native 262K: Atlas rejects a prompt past the served window, and the prompt-size
+    # guard reads this number. The completion clamp matches the Ollama entry above.
+    "Qwen/Qwen3.8-27B-FP8": ModelSpec(
+        name="Qwen/Qwen3.8-27B-FP8",
+        context_window=32_768,
+        default_max_completion=8_192,
+        reasoning_control=ReasoningControl.TOGGLE,
+    ),
     "llama3:70b": ModelSpec(
         name="llama3:70b",
         context_window=131_072,

--- a/src/squadops/llm/models.py
+++ b/src/squadops/llm/models.py
@@ -63,6 +63,9 @@ class LLMResponse:
     completion_tokens: int | None = None
     total_tokens: int | None = None
     tokens_per_second: float | None = None
+    # Reasoning tokens counted separately from content, when the provider reports them
+    # (``thinking_tokens: True``). None = not reported; never zero-filled (#410, #1159).
+    reasoning_tokens: int | None = None
 
 
 @dataclass(frozen=True)
@@ -93,3 +96,4 @@ class ChatMessage:
     completion_tokens: int | None = None
     total_tokens: int | None = None
     tokens_per_second: float | None = None
+    reasoning_tokens: int | None = None  # see LLMResponse.reasoning_tokens

--- a/tests/unit/llm/conformance.py
+++ b/tests/unit/llm/conformance.py
@@ -33,6 +33,7 @@ from unittest.mock import patch
 
 import httpx
 
+from adapters.llm.atlas import AtlasAdapter
 from adapters.llm.ollama import OllamaAdapter
 from adapters.llm.vllm import VLLMAdapter
 from squadops.ports.llm.provider import LLMPort
@@ -310,6 +311,111 @@ def vllm_nameless_model(request: httpx.Request) -> httpx.Response:
 
 
 # ---------------------------------------------------------------------------
+# Atlas dialect — the shapes measured on the Spark on 2026-08-28 (SIP-0106 §10.2).
+# ---------------------------------------------------------------------------
+
+ATLAS_MODELS = ["Qwen/Qwen3.8-27B-FP8"]
+ATLAS_CONTENT = "the assembled answer"
+ATLAS_STREAM_PARTS = ["the ", "assembled ", "answer"]
+ATLAS_TOKEN = "test-bearer-token"
+_ATLAS_PROMPT_TOKENS = 20
+_ATLAS_COMPLETION_TOKENS = 40
+_ATLAS_REASONING_TOKENS = 12
+_ATLAS_TPS = 12.78
+
+
+def _atlas_usage() -> dict:
+    return {
+        "prompt_tokens": _ATLAS_PROMPT_TOKENS,
+        "completion_tokens": _ATLAS_COMPLETION_TOKENS,
+        "total_tokens": _ATLAS_PROMPT_TOKENS + _ATLAS_COMPLETION_TOKENS,
+        "prompt_tokens_details": {"cached_tokens": 0, "audio_tokens": 0},
+        "completion_tokens_details": {"reasoning_tokens": _ATLAS_REASONING_TOKENS},
+        "time_to_first_token_ms": 153.2,
+        "response_token/s": _ATLAS_TPS,
+    }
+
+
+def atlas_ok(request: httpx.Request) -> httpx.Response:
+    """Answer as the live Atlas did: bearer-gated, reasoning in its own field, the
+    engine's own decode rate in usage, and the streaming usage on an empty-choices frame."""
+    if request.headers.get("Authorization") != f"Bearer {ATLAS_TOKEN}":
+        return httpx.Response(401, json={"error": {"message": "unauthorized"}})
+    path = request.url.path
+
+    if path == "/v1/models":
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [
+                    {
+                        "id": m,
+                        "object": "model",
+                        "created": 0,
+                        "owned_by": "atlas",
+                        "max_model_len": 32768,
+                    }
+                    for m in ATLAS_MODELS
+                ],
+            },
+        )
+
+    if path == "/v1/chat/completions":
+        body = json.loads(request.content)
+        model = body["model"]
+        if body.get("reasoning_effort") == "high":  # the served template's answer, measured
+            return httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "message": "Unexpected reasoning effort high. Supported types are xhigh (default), medium, and low."
+                    }
+                },
+            )
+        if not body.get("stream"):
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl-1",
+                    "model": model,
+                    "system_fingerprint": "fp_atlas",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "reasoning_content": "thinking, separately",
+                                "content": ATLAS_CONTENT,
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": _atlas_usage(),
+                },
+            )
+        frames: list[dict] = [{"choices": [{"index": 0, "delta": {"role": "assistant"}}]}]
+        frames.append({"choices": [{"index": 0, "delta": {"reasoning_content": "thinking, "}}]})
+        frames.extend(
+            {"choices": [{"index": 0, "delta": {"content": part}}]} for part in ATLAS_STREAM_PARTS
+        )
+        frames.append({"choices": [], "usage": _atlas_usage()})
+        frames.append({"choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]})
+        return httpx.Response(200, content=_sse(frames))
+
+    return httpx.Response(404, json={"error": {"message": "not found"}})
+
+
+def atlas_nameless_model(request: httpx.Request) -> httpx.Response:
+    if (
+        request.url.path == "/v1/models"
+        and request.headers.get("Authorization") == f"Bearer {ATLAS_TOKEN}"
+    ):
+        return httpx.Response(200, json={"object": "list", "data": [{"object": "model"}]})
+    return atlas_ok(request)
+
+
+# ---------------------------------------------------------------------------
 # The registry — one entry per adapter under conformance.
 #
 # Atlas (P4) and vLLM (P6) each land here as one AdapterCase with their own
@@ -350,6 +456,25 @@ ADAPTER_CASES: list[AdapterCase] = [
         # The registry is keyed on the name the adapter is handed; a real vLLM
         # serves HF paths, whose entries are #1145/#1159's to add.
         reasoning_model="qwen3.6:27b",
+    ),
+    AdapterCase(
+        name="atlas",
+        build=lambda: AtlasAdapter(
+            base_url="http://localhost:8888",
+            default_model="Qwen/Qwen3.8-27B-FP8",
+            timeout_seconds=5.0,
+            api_key=ATLAS_TOKEN,
+        ),
+        ok=atlas_ok,
+        nameless_model=atlas_nameless_model,
+        default_model="Qwen/Qwen3.8-27B-FP8",
+        override_model="Qwen/Qwen3.8-27B-FP8",
+        models=ATLAS_MODELS,
+        content=ATLAS_CONTENT,
+        prompt_tokens=_ATLAS_PROMPT_TOKENS,
+        completion_tokens=_ATLAS_COMPLETION_TOKENS,
+        tokens_per_second=_ATLAS_TPS,  # exact: the engine's own `response_token/s`
+        reasoning_model="Qwen/Qwen3.8-27B-FP8",
     ),
 ]
 

--- a/tests/unit/llm/test_atlas_adapter.py
+++ b/tests/unit/llm/test_atlas_adapter.py
@@ -1,0 +1,136 @@
+"""Atlas dialect specifics (Atlas Provider Adapter SIP, SIP-0106, P4).
+
+The shared conformance suite owns the contract. This file owns what is true of Atlas
+in particular, each item measured on the Spark on 2026-08-28 (#1158): the bearer gate,
+the reasoning ladder's `high` rejection, thinking in its own field, and the engine's
+own decode rate.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from adapters.llm.atlas import AtlasAdapter
+from squadops.llm.exceptions import LLMConnectionError
+from squadops.llm.models import ChatMessage, ReasoningLevel
+from tests.unit.llm.conformance import ATLAS_TOKEN, atlas_ok, wire
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+
+def _adapter(api_key: str | None = ATLAS_TOKEN) -> AtlasAdapter:
+    return AtlasAdapter(
+        base_url="http://localhost:8888",
+        default_model="Qwen/Qwen3.8-27B-FP8",
+        timeout_seconds=5.0,
+        api_key=api_key,
+    )
+
+
+def _messages() -> list[ChatMessage]:
+    return [ChatMessage(role="user", content="the question")]
+
+
+class TestBearerGate:
+    async def test_a_missing_token_is_named_not_reported_as_a_network_failure(self):
+        """The bug: a 401 surfacing as "failed to connect" sends the operator to the
+        firewall; the setting to fix is SQUADOPS__LLM__API_KEY."""
+        with wire(atlas_ok), pytest.raises(LLMConnectionError, match="SQUADOPS__LLM__API_KEY"):
+            await _adapter(api_key=None).chat(_messages())
+
+    async def test_health_reports_a_rejected_token_without_raising(self):
+        with wire(atlas_ok):
+            report = await _adapter(api_key="wrong").health()
+        assert report["healthy"] is False
+        assert "SQUADOPS__LLM__API_KEY" in report["error"]
+
+
+class TestReasoningEffort:
+    @pytest.mark.parametrize(
+        ("level", "effort"),
+        [
+            (ReasoningLevel.NONE, "none"),
+            (ReasoningLevel.LOW, "low"),
+            (ReasoningLevel.MEDIUM, "medium"),
+            (ReasoningLevel.HIGH, "xhigh"),  # the served template rejects `high`
+        ],
+    )
+    async def test_the_level_maps_onto_the_served_ladder(self, level, effort):
+        """`high` passed through blind is a 400 from the Qwen3.8 template; `xhigh` is
+        its top tier. Every other level is verbatim, including a real `none`."""
+        seen: list[dict] = []
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            seen.append(json.loads(request.content))
+            return atlas_ok(request)
+
+        with wire(capture):
+            await _adapter().chat(_messages(), reasoning=level)
+        assert seen[0]["reasoning_effort"] == effort
+
+    async def test_no_level_sends_no_effort_field(self):
+        seen: list[dict] = []
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            seen.append(json.loads(request.content))
+            return atlas_ok(request)
+
+        with wire(capture):
+            await _adapter().chat(_messages())
+        assert "reasoning_effort" not in seen[0]
+
+
+class TestThinkingChannel:
+    async def test_reasoning_tokens_are_reported_separately(self):
+        with wire(atlas_ok):
+            msg = await _adapter().chat(_messages())
+        assert msg.reasoning_tokens == 12
+        assert msg.completion_tokens == 40
+
+    async def test_streamed_reasoning_deltas_are_not_spliced_into_content(self):
+        """`delta.reasoning_content` is the thinking channel; it must not reach the
+        fenced parser as output."""
+        with wire(atlas_ok):
+            chunks = [c async for c in _adapter().chat_stream(_messages())]
+            assembled = await _adapter().chat_stream_with_usage(_messages())
+        assert "".join(chunks) == "the assembled answer"
+        assert assembled.content == "the assembled answer"
+        assert assembled.reasoning_tokens == 12
+
+    async def test_absent_reasoning_details_stay_none_not_zero(self):
+        def no_details(request: httpx.Request) -> httpx.Response:
+            response = atlas_ok(request)
+            if request.url.path != "/v1/chat/completions":
+                return response
+            body = json.loads(response.content)
+            body["usage"].pop("completion_tokens_details")
+            return httpx.Response(200, json=body)
+
+        with wire(no_details):
+            msg = await _adapter().chat(_messages())
+        assert msg.reasoning_tokens is None
+
+
+class TestThroughput:
+    async def test_the_engines_own_rate_is_reported_verbatim(self):
+        """Atlas measures its decode phase; a wall-clock derivation here would be a
+        different quantity (inclusive of prefill) labelled the same."""
+        with wire(atlas_ok):
+            msg = await _adapter().chat(_messages())
+        assert msg.tokens_per_second == 12.78
+
+    async def test_wall_clock_fallback_only_when_the_field_is_absent(self):
+        def no_rate(request: httpx.Request) -> httpx.Response:
+            response = atlas_ok(request)
+            if request.url.path != "/v1/chat/completions":
+                return response
+            body = json.loads(response.content)
+            body["usage"].pop("response_token/s")
+            return httpx.Response(200, json=body)
+
+        with wire(no_rate):
+            msg = await _adapter().chat(_messages())
+        assert msg.tokens_per_second is not None and msg.tokens_per_second > 0

--- a/tests/unit/llm/test_factory.py
+++ b/tests/unit/llm/test_factory.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import pytest
 
+from adapters.llm.atlas import AtlasAdapter
 from adapters.llm.factory import create_llm_provider
 from adapters.llm.ollama import OllamaAdapter
 from adapters.llm.vllm import VLLMAdapter
@@ -23,18 +24,19 @@ def test_a_missing_provider_is_an_error_not_ollama():
 
 @pytest.mark.parametrize(
     ("name", "cls"),
-    [("ollama", OllamaAdapter), ("vllm", VLLMAdapter)],
+    [("ollama", OllamaAdapter), ("vllm", VLLMAdapter), ("atlas", AtlasAdapter)],
 )
 def test_each_registered_name_resolves_its_own_adapter(name, cls):
     adapter = create_llm_provider(provider=name, base_url="http://x:1", default_model="m")
     assert type(adapter) is cls
 
 
-def test_vllm_receives_its_api_key():
+@pytest.mark.parametrize("name", ["vllm", "atlas"])
+def test_bearer_providers_receive_their_api_key(name):
     """The one provider-specific kwarg the factory forwards; dropped, a bearer-gated
     server (Atlas is one) answers 401 to every call."""
     adapter = create_llm_provider(
-        provider="vllm", base_url="http://x:1", default_model="m", api_key="tok"
+        provider=name, base_url="http://x:1", default_model="m", api_key="tok"
     )
     assert adapter._api_key == "tok"
 

--- a/tests/unit/llm/test_model_registry.py
+++ b/tests/unit/llm/test_model_registry.py
@@ -35,6 +35,14 @@ class TestModelSpec:
         assert MODEL_SPECS["qwen3.8:27b"].reasoning_control == ReasoningControl.TOGGLE
         assert MODEL_SPECS["qwen2.5:7b"].reasoning_control == ReasoningControl.NONE
 
+    def test_the_atlas_served_id_is_registered_with_the_served_window(self):
+        """Atlas names the weights by HF path; unregistered, the resolver sends no
+        reasoning level (the channel stays on) and the prompt guard has no window —
+        and the window must be the served one, since Atlas rejects prompts past it."""
+        spec = MODEL_SPECS["Qwen/Qwen3.8-27B-FP8"]
+        assert spec.context_window == 32_768
+        assert spec.default_max_completion == MODEL_SPECS["qwen3.8:27b"].default_max_completion
+
     def test_all_specs_context_exceeds_completion(self):
         """Every registered model must have context_window > default_max_completion."""
         for name, spec in MODEL_SPECS.items():


### PR DESCRIPTION
## What

SIP-0106 P4, built from the accepted spec and the 2026-08-28 measurements on #1158 rather than the vendor's docs.

- **`adapters/llm/atlas.py`**, selected by `SQUADOPS__LLM__PROVIDER=atlas` — its own file, not a subclass of the vLLM adapter (§3.5a), because the dialect diverges where it matters:
  - **Bearer gate**: mandatory once the server is bound off localhost. New `LLMConfig.api_key` (a `secret://` ref the loader resolves), forwarded from both composition roots; a 401 is translated to an error that names `SQUADOPS__LLM__API_KEY` instead of "failed to connect". `health()` reports it without raising.
  - **Throughput**: the engine's own `response_token/s` is reported verbatim; wall-clock derivation (the vLLM adapter's number, inclusive of prefill) only when the field is absent.
  - **Thinking channel**: `completion_tokens_details.reasoning_tokens` surfaced through a new `reasoning_tokens` field on `ChatMessage`/`LLMResponse` (None when not reported, never zero) — `thinking_tokens: True`. Streamed `delta.reasoning_content` frames are skipped, never spliced into content.
  - **Reasoning**: the port's level → `reasoning_effort` verbatim (`none|low|medium`) except **`high → xhigh`** — the served Qwen3.8 template accepts only `low|medium|xhigh` and 400s on `high` (measured).
  - Listing via `/v1/models` (ids are HF paths, verbatim); no model management (405/404 observed); SSE with usage on a `choices: []` frame.
- **`Qwen/Qwen3.8-27B-FP8`** joins the model registry — provider-scoped identity (§3.4) — with the **served** 32K window from the `local-spark` recipe, not the checkpoint's native 262K, since Atlas rejects prompts past what it serves and the prompt guard reads this number.
- **Conformance**: Atlas is the suite's third `AdapterCase`, with handlers shaped exactly as the live server answered (bearer-gated, reasoning in its own field, native rate, `high` → 400). No shared assertion changed.

**Not here:** the deploy surfaces for `provider=atlas` (compose `secrets:` entry + `SQUADOPS__LLM__API_KEY`) — those ride the switch PR (SIP-0106 §5 Switch row); the LangFuse record of reasoning tokens (#410's half); the `local-spark` bootstrap entry (#1158's remainder).

## Closes

Closes #1159
Refs #410 — remaining: the Ollama read half (`message.thinking`) and `GenerationRecord` carrying reasoning tokens to LangFuse.

## Evidence

- `run_regression_tests.sh`: **8,237 passed**, all gates (conformance ×3 adapters; dialect tests for the gate, the ladder, the channel, the rate; factory and registry tests).
- **Live, through the adapter, against Atlas on the Spark** (`avarok/atlas-gb10:latest`, `Qwen/Qwen3.8-27B-FP8`, ready ~30 s after `docker start`):

  | check | result |
  |---|---|
  | wrong token | `health()` → `healthy: false, error: "bearer token rejected (set SQUADOPS__LLM__API_KEY)"`; `chat()` → `LLMConnectionError: Atlas rejected the bearer token (401): set SQUADOPS__LLM__API_KEY …` |
  | `capabilities()` | listing ✓ management ✗ streaming_usage ✓ thinking_tokens ✓ reasoning_control ✓ |
  | `list_available_models()` | `["Qwen/Qwen3.8-27B-FP8"]` |
  | `chat_stream_with_usage`, fill brief, `max_tokens 2500` — `none` | 256 completion / **0 reasoning** / 12.76 t/s / 3 of 3 slots / 20.5 s |
  | — `medium` | 451 / 224 / 12.68 t/s / 3 of 3 / 36.0 s |
  | — `high` (sent as `xhigh`) | 2,500 (the cap) / **2,251 reasoning** / 12.64 t/s / 2 of 3 / 198.2 s |
  | `chat(… reasoning=none)` "Say OK." | `"OK"`, 2 tokens, 0 reasoning, 12.7 t/s |
  | `chat_stream` content-only | reasoning deltas excluded (a 20-token budget at `medium` left only `"\n\n"` of content — the thinking took it, correctly out of the text) |

  The `high` row is the design speaking: at this `max_tokens`, `xhigh`'s budget (`max_tokens × 0.9`) is spent thinking and the fill loses a slot — exactly why `reasoning_policy` declares `qa.test` as `none`. Reported as measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbzZWzB8VgjZdbtKX9N41L
