### PR TITLE
docs(plan): 1.7.0 Atlas A/B pre-registration — two deploys, arm B tuned (FP8 + MTP K=4); full-38-atlas profile; the compose override that points the deploy at Atlas (#1160)

### DIFF
--- a/config/squad-profiles.yaml
+++ b/config/squad-profiles.yaml
@@ -39,6 +39,18 @@ profiles:
       - { agent_id: eve, role: qa, model: "qwen3.8:27b", enabled: true, config_overrides: { max_completion_tokens: 12288 } }
       - { agent_id: data, role: data, model: "qwen3.8:27b", enabled: true }
 
+  - profile_id: full-38-atlas
+    name: "Full Squad (qwen3.8) on Atlas"
+    description: "The `full-38` roster verbatim with the model named the way Atlas serves it — the HuggingFace path (SIP-0106 §3.4: model identity is provider-scoped). Exists ONLY as arm B of the 1.7.0 Atlas A/B (#1160); `full-38` on Ollama is arm A and the meaning of every historical record. Same eve budget override as `full-38`."
+    version: 1
+    agents:
+      - { agent_id: max, role: lead, model: "Qwen/Qwen3.8-27B-FP8", enabled: true }
+      - { agent_id: neo, role: dev, model: "Qwen/Qwen3.8-27B-FP8", enabled: true }
+      - { agent_id: nat, role: strat, model: "Qwen/Qwen3.8-27B-FP8", enabled: true }
+      - { agent_id: bob, role: builder, model: "Qwen/Qwen3.8-27B-FP8", enabled: true }
+      - { agent_id: eve, role: qa, model: "Qwen/Qwen3.8-27B-FP8", enabled: true, config_overrides: { max_completion_tokens: 12288 } }
+      - { agent_id: data, role: data, model: "Qwen/Qwen3.8-27B-FP8", enabled: true }
+
   - profile_id: full
     name: "Full Squad"
     description: "All 6 roles incl. builder on qwen3.6:27b — uniform single-loaded model on Spark (no swap overhead), max reasoning depth at the ~16 tps ceiling. The quality squad. (Consolidates the former full-squad + spark-squad-with-builder; #173.)"

--- a/docker-compose.atlas.yml
+++ b/docker-compose.atlas.yml
@@ -1,0 +1,68 @@
+services:
+  runtime-api:
+    environment:
+      SQUADOPS__LLM__PROVIDER: atlas
+      SQUADOPS__LLM__URL: http://host.docker.internal:8888
+      SQUADOPS__LLM__MODEL: "${ATLAS_MODEL:?set ATLAS_MODEL to the HF id Atlas serves}"
+      SQUADOPS__LLM__API_KEY: secret://atlas_api_key
+    secrets:
+      - atlas_api_key
+  max:
+    environment:
+      SQUADOPS__LLM__PROVIDER: atlas
+      SQUADOPS__LLM__URL: http://host.docker.internal:8888
+      SQUADOPS__LLM__MODEL: "${ATLAS_MODEL:?set ATLAS_MODEL to the HF id Atlas serves}"
+      SQUADOPS__LLM__API_KEY: secret://atlas_api_key
+    secrets:
+      - atlas_api_key
+  nat:
+    environment:
+      SQUADOPS__LLM__PROVIDER: atlas
+      SQUADOPS__LLM__URL: http://host.docker.internal:8888
+      SQUADOPS__LLM__MODEL: "${ATLAS_MODEL:?set ATLAS_MODEL to the HF id Atlas serves}"
+      SQUADOPS__LLM__API_KEY: secret://atlas_api_key
+    secrets:
+      - atlas_api_key
+  neo:
+    environment:
+      SQUADOPS__LLM__PROVIDER: atlas
+      SQUADOPS__LLM__URL: http://host.docker.internal:8888
+      SQUADOPS__LLM__MODEL: "${ATLAS_MODEL:?set ATLAS_MODEL to the HF id Atlas serves}"
+      SQUADOPS__LLM__API_KEY: secret://atlas_api_key
+    secrets:
+      - atlas_api_key
+  eve:
+    environment:
+      SQUADOPS__LLM__PROVIDER: atlas
+      SQUADOPS__LLM__URL: http://host.docker.internal:8888
+      SQUADOPS__LLM__MODEL: "${ATLAS_MODEL:?set ATLAS_MODEL to the HF id Atlas serves}"
+      SQUADOPS__LLM__API_KEY: secret://atlas_api_key
+    secrets:
+      - atlas_api_key
+  data:
+    environment:
+      SQUADOPS__LLM__PROVIDER: atlas
+      SQUADOPS__LLM__URL: http://host.docker.internal:8888
+      SQUADOPS__LLM__MODEL: "${ATLAS_MODEL:?set ATLAS_MODEL to the HF id Atlas serves}"
+      SQUADOPS__LLM__API_KEY: secret://atlas_api_key
+    secrets:
+      - atlas_api_key
+  bob:
+    environment:
+      SQUADOPS__LLM__PROVIDER: atlas
+      SQUADOPS__LLM__URL: http://host.docker.internal:8888
+      SQUADOPS__LLM__MODEL: "${ATLAS_MODEL:?set ATLAS_MODEL to the HF id Atlas serves}"
+      SQUADOPS__LLM__API_KEY: secret://atlas_api_key
+    secrets:
+      - atlas_api_key
+  joi:
+    environment:
+      SQUADOPS__LLM__PROVIDER: atlas
+      SQUADOPS__LLM__URL: http://host.docker.internal:8888
+      SQUADOPS__LLM__MODEL: "${ATLAS_MODEL:?set ATLAS_MODEL to the HF id Atlas serves}"
+      SQUADOPS__LLM__API_KEY: secret://atlas_api_key
+    secrets:
+      - atlas_api_key
+secrets:
+  atlas_api_key:
+    file: ./secrets/atlas_api_key.txt

--- a/docs/plans/1-7-0-atlas-ab-preregistration.md
+++ b/docs/plans/1-7-0-atlas-ab-preregistration.md
@@ -1,0 +1,67 @@
+# 1.7.0 — the Atlas A/B, pre-registration (#1160, SIP-0106 P5)
+
+**Written 2026-08-28, before any counting cycle.** The artifact the switch decision reads
+(SIP-0106 §3.6.1, §4.2). Two deploys, not two engines: the owner's ruling of 2026-08-28 —
+*"keep Ollama fixed at what we have been running basically out of the box, but put the
+effort to determine a better tuned config on the Atlas side"* — replaces Appendix C's
+"same weights at the same quantization" precondition with **each arm is its production
+configuration, stated in full**. The tuning pass that chose arm B is on #1160.
+
+## 1. Fixed parameters
+
+| | Arm A — Ollama (production, untouched) | Arm B — Atlas (tuned) |
+|---|---|---|
+| squad profile | `full-38` | `full-38-atlas` — the same roster and eve override, model named as Atlas serves it |
+| model | `qwen3.8:27b`, **Q4_K_M** (Ollama's tag), 262K native window | `Qwen/Qwen3.8-27B-FP8`, **FP8 dequantized to BF16 in memory**, served window 32K |
+| engine | Ollama 0.32.14 as deployed; no tuning — every 1.6.x record sits on it | `avarok/atlas-gb10:latest` (built 2026-08-15), `serve Qwen/Qwen3.8-27B-FP8 --speculative --num-drafts 3 --enable-prefix-caching --scheduling-policy slai --kv-cache-dtype fp8 --max-seq-len 32768 --gpu-memory-utilization 0.75 --bind 0.0.0.0 --require-auth --auth-tokens-file … --no-auto-swap --no-tui` |
+| why that serve line | — | the tuning matrix (#1160): FP8 12.5 t/s → MTP speculative K=3 29.5 → **K=4 33.8** → K=5 23.0 (over-drafting); NVFP4 12.8 and also dequantized (no memory or speed gain). Token counts identical across rows on the fill brief |
+| how the deploy is pointed at B | — | `docker compose -f docker-compose.yml -f docker-compose.atlas.yml up -d` (`ATLAS_MODEL=Qwen/Qwen3.8-27B-FP8`, secret `atlas_api_key`); back to A with plain `docker compose up -d`. Recreating the containers is also Appendix C.3's "restart the agent containers between arms" |
+| project / request profile | `group_run` / `validated-fullstack` | same |
+| stacks | **Next.js+TS** (`nextjs_ts` overrides) for the paired wall-clock — the 1.6.6 arm that ran 6/6, so verdict noise does not swamp the pair; then **one FastAPI+React pair** for correction texture (Appendix C.3's sleeper metric needs a stack where corrections happen — 1.6.6 ran 4/6 there) | same |
+| order | **A1, B1, B2, A2** (Next.js), then **A3, B3** (FastAPI+React) — the first pair A-first, the second B-first, so an ordering effect shows instead of being credited to one side | |
+| shakeout | one non-counting Atlas cycle before B1 (no cycle has ever run on Atlas: the model preflight over `/v1/models`, the 32K guard, the fenced parser on Atlas output, timeouts at 2.8× decode). It is also the warm-up Appendix C.2 requires, recorded and flagged | |
+| frozen deploy | agent images from `43721563` (`max=22429f8898cb neo=af175877d8b5 eve=fde6d6b0fb26 bob=5d2e2f19e9be nat=864419a35f7f data=feaa005116b7 joi=7e6173048297`); runtime-api rebuilt once on the commit that carries `full-38-atlas` (its image id pinned in the set files after that rebuild) and identical for both arms | |
+| engine isolation (C.2) | before every B cycle: `ollama ps` empty (keep-alive has paged the models out); before every A cycle: the `atlas` container stopped. Neither checkpoint coexists with Ollama-27B in the Spark's unified memory at usable KV | |
+
+## 2. Preconditions — all, or the numbers lie
+
+1. #927, #1157, #1159 merged and deployed; `provider` and the adapter verified in-container (done 2026-08-28).
+2. The `full-38-atlas` profile on main and seeded (squad-profile provider is `config`: a runtime-api rebuild); `docker compose … config` renders the override on all eight services.
+3. Atlas: ufw allow on `:8888` (owner, 2026-08-28), token secret at `secrets/atlas_api_key.txt`, kernel audit `236/0` on this checkpoint, the serve line above answering `/v1/models` with the token.
+4. Per-arm `loaded_checks`: runtime-api and an agent print `config.llm.provider` and the served model — the arm is what the record says it is.
+5. No other cycle, set, or deploy change while open.
+
+## 3. Predictions — falsifiable from the record, one per mechanism
+
+| # | Prediction | Read from |
+|---|---|---|
+| P1 | On `none` generations (qa fill, repairs, verdicts) arm B's decode rate is ≥ 2× arm A's | LangFuse `tokens_per_second` per generation (B: the engine's own `response_token/s`; A: Ollama `eval_count/eval_duration` — both decode rates) |
+| P2 | Paired cycle wall-clock B < A on every Next.js pair | the driver's `wall_clock_seconds` |
+| P3 | Verdict parity: no arm-B rejection whose per-round evidence names the runner (extraction failure, parse, timeout, 401/400 from Atlas) | per-round `test_report.md` / handler logs, never the roll-up (the per-round-evidence rule) |
+| P4 | Completion tokens per task type within ±20% between arms — if not, the difference is thinking posture, and speed is normalized per token before any claim (C.4 reading order, item 1) | LangFuse `completion_tokens` by capability |
+| P5 | Every qa-fill generation on arm B carries `reasoning_tokens = 0` — the policy's `none` reaches Atlas's wire | LangFuse (`GenerationRecord.reasoning`) and Atlas usage |
+| P6 | The FastAPI+React pair: corrections consumed on B ≤ A (the sleeper metric; one pair is texture, not a bar) | the driver's `correction_rounds` |
+
+A falsified prediction stops the set for a read, not a fix — the 1.6.x rule.
+
+## 4. The artifact
+
+`docs/plans/1-7-0-atlas-ab-record.md`: one row per cycle — arm, order, cycle id, verdict,
+checks executed/passed, correction rounds, extraction health, `wall_clock_seconds`; then
+per-generation medians by capability (completion tokens, reasoning tokens where reported,
+decode t/s) from LangFuse; the shakeout and warm-up rows present and flagged. Read in
+Appendix C.4's order: tokens first, then paired wall-clock, then rate, then the quality
+half. **No threshold** (Ruling 2): the artifact reports; the owner decides.
+
+## 5. Appendix C amendments this artifact records
+
+- C.1-1 superseded: each arm is its production configuration, stated (Ruling of 2026-08-28).
+- `load_ms` is not emitted by Atlas: the shakeout/warm-up is recorded and flagged, and
+  TTFT stability is the warm guard; `prefill_ms`/`total_ms` → TTFT and client wall-clock.
+- Corpus = real cycles, not a frozen prompt set (no full-prompt store exists; LangFuse caps
+  `input` at 10k chars).
+
+## 6. Prohibited while open
+
+No Ollama tuning; no profile edits; no deploy change other than the arm switch; no other
+cycles on the box; the record written from per-round evidence before any conclusion.

--- a/docs/plans/1-7-0-atlas-ab-preregistration.md
+++ b/docs/plans/1-7-0-atlas-ab-preregistration.md
@@ -46,7 +46,7 @@ A falsified prediction stops the set for a read, not a fix — the 1.6.x rule.
 
 ## 4. The artifact
 
-`docs/plans/1-7-0-atlas-ab-record.md`: one row per cycle — arm, order, cycle id, verdict,
+The record, written beside this file at the close (`1-7-0-atlas-ab-record`): one row per cycle — arm, order, cycle id, verdict,
 checks executed/passed, correction rounds, extraction health, `wall_clock_seconds`; then
 per-generation medians by capability (completion tokens, reasoning tokens where reported,
 decode t/s) from LangFuse; the shakeout and warm-up rows present and flagged. Read in

--- a/docs/plans/verification-sets/1-7-0-ab-atlas-fastapi-react.yaml
+++ b/docs/plans/verification-sets/1-7-0-ab-atlas-fastapi-react.yaml
@@ -1,0 +1,27 @@
+# 1.7.0 Atlas A/B (#1160), arm ATLAS — FastAPI+React pair (correction texture). Pre-registration:
+# docs/plans/1-7-0-atlas-ab-preregistration.md. Rolls interleave with the other arm
+# (A3, B3); the arm switch and engine isolation are manual between rolls.
+name: 1-7-0-ab-atlas-fastapi-react
+pre_registration: docs/plans/1-7-0-atlas-ab-preregistration.md
+project: group_run
+squad_profile: full-38-atlas
+request_profile: validated-fullstack
+overrides: {}
+gate_name: progress_plan_review
+n_rolls: 1
+gate_notes: >-
+  1.7.0 Atlas A/B, arm atlas. Approved under the pre-registered gate policy — identical text
+  applied to every roll of this set. System plan validation passed; no additional judgment applied.
+launch_notes: >-
+  1.7.0 Atlas A/B — arm atlas, COUNTED roll {roll} of {n} on fastapi-react_ts. Frozen deploy per the
+  pre-registration; predictions P1, P3, P4, P6; the pair's other arm is the comparison.
+shakeout_notes: >-
+  1.7.0 Atlas A/B — arm atlas SHAKEOUT, NON-COUNTING by declaration before launch: the first
+  cycle ever on this engine; also the warm-up Appendix C.2 requires, recorded and flagged.
+loaded_checks:
+  runtime-api: >-
+    from squadops.config import load_config; c = load_config();
+    print(c.llm.provider, c.llm.model, c.llm.url)
+  eve: >-
+    from squadops.config import load_config; c = load_config();
+    print(c.llm.provider, c.llm.model, c.llm.url)

--- a/docs/plans/verification-sets/1-7-0-ab-atlas-nextjs.yaml
+++ b/docs/plans/verification-sets/1-7-0-ab-atlas-nextjs.yaml
@@ -1,0 +1,29 @@
+# 1.7.0 Atlas A/B (#1160), arm ATLAS — Next.js+TS pairs. Pre-registration:
+# docs/plans/1-7-0-atlas-ab-preregistration.md. Rolls interleave with the other arm
+# (A1, B1, B2, A2); the arm switch and engine isolation are manual between rolls.
+name: 1-7-0-ab-atlas-nextjs
+pre_registration: docs/plans/1-7-0-atlas-ab-preregistration.md
+project: group_run
+squad_profile: full-38-atlas
+request_profile: validated-fullstack
+overrides:
+  build_profile: nextjs_ts
+  dev_capability: nextjs_ts
+gate_name: progress_plan_review
+n_rolls: 2
+gate_notes: >-
+  1.7.0 Atlas A/B, arm atlas. Approved under the pre-registered gate policy — identical text
+  applied to every roll of this set. System plan validation passed; no additional judgment applied.
+launch_notes: >-
+  1.7.0 Atlas A/B — arm atlas, COUNTED roll {roll} of {n} on nextjs_ts. Frozen deploy per the
+  pre-registration; predictions P1–P5; the pair's other arm is the comparison.
+shakeout_notes: >-
+  1.7.0 Atlas A/B — arm atlas SHAKEOUT, NON-COUNTING by declaration before launch: the first
+  cycle ever on this engine; also the warm-up Appendix C.2 requires, recorded and flagged.
+loaded_checks:
+  runtime-api: >-
+    from squadops.config import load_config; c = load_config();
+    print(c.llm.provider, c.llm.model, c.llm.url)
+  eve: >-
+    from squadops.config import load_config; c = load_config();
+    print(c.llm.provider, c.llm.model, c.llm.url)

--- a/docs/plans/verification-sets/1-7-0-ab-ollama-fastapi-react.yaml
+++ b/docs/plans/verification-sets/1-7-0-ab-ollama-fastapi-react.yaml
@@ -1,0 +1,27 @@
+# 1.7.0 Atlas A/B (#1160), arm OLLAMA — FastAPI+React pair (correction texture). Pre-registration:
+# docs/plans/1-7-0-atlas-ab-preregistration.md. Rolls interleave with the other arm
+# (A3, B3); the arm switch and engine isolation are manual between rolls.
+name: 1-7-0-ab-ollama-fastapi-react
+pre_registration: docs/plans/1-7-0-atlas-ab-preregistration.md
+project: group_run
+squad_profile: full-38
+request_profile: validated-fullstack
+overrides: {}
+gate_name: progress_plan_review
+n_rolls: 1
+gate_notes: >-
+  1.7.0 Atlas A/B, arm ollama. Approved under the pre-registered gate policy — identical text
+  applied to every roll of this set. System plan validation passed; no additional judgment applied.
+launch_notes: >-
+  1.7.0 Atlas A/B — arm ollama, COUNTED roll {roll} of {n} on fastapi-react_ts. Frozen deploy per the
+  pre-registration; predictions P1, P3, P4, P6; the pair's other arm is the comparison.
+shakeout_notes: >-
+  1.7.0 Atlas A/B — arm ollama SHAKEOUT, NON-COUNTING by declaration before launch: the first
+  cycle ever on this engine; also the warm-up Appendix C.2 requires, recorded and flagged.
+loaded_checks:
+  runtime-api: >-
+    from squadops.config import load_config; c = load_config();
+    print(c.llm.provider, c.llm.model, c.llm.url)
+  eve: >-
+    from squadops.config import load_config; c = load_config();
+    print(c.llm.provider, c.llm.model, c.llm.url)

--- a/docs/plans/verification-sets/1-7-0-ab-ollama-nextjs.yaml
+++ b/docs/plans/verification-sets/1-7-0-ab-ollama-nextjs.yaml
@@ -1,0 +1,29 @@
+# 1.7.0 Atlas A/B (#1160), arm OLLAMA — Next.js+TS pairs. Pre-registration:
+# docs/plans/1-7-0-atlas-ab-preregistration.md. Rolls interleave with the other arm
+# (A1, B1, B2, A2); the arm switch and engine isolation are manual between rolls.
+name: 1-7-0-ab-ollama-nextjs
+pre_registration: docs/plans/1-7-0-atlas-ab-preregistration.md
+project: group_run
+squad_profile: full-38
+request_profile: validated-fullstack
+overrides:
+  build_profile: nextjs_ts
+  dev_capability: nextjs_ts
+gate_name: progress_plan_review
+n_rolls: 2
+gate_notes: >-
+  1.7.0 Atlas A/B, arm ollama. Approved under the pre-registered gate policy — identical text
+  applied to every roll of this set. System plan validation passed; no additional judgment applied.
+launch_notes: >-
+  1.7.0 Atlas A/B — arm ollama, COUNTED roll {roll} of {n} on nextjs_ts. Frozen deploy per the
+  pre-registration; predictions P1–P5; the pair's other arm is the comparison.
+shakeout_notes: >-
+  1.7.0 Atlas A/B — arm ollama SHAKEOUT, NON-COUNTING by declaration before launch: the first
+  cycle ever on this engine; also the warm-up Appendix C.2 requires, recorded and flagged.
+loaded_checks:
+  runtime-api: >-
+    from squadops.config import load_config; c = load_config();
+    print(c.llm.provider, c.llm.model, c.llm.url)
+  eve: >-
+    from squadops.config import load_config; c = load_config();
+    print(c.llm.provider, c.llm.model, c.llm.url)

--- a/tests/unit/cycles/test_squad_profile_builder.py
+++ b/tests/unit/cycles/test_squad_profile_builder.py
@@ -74,7 +74,9 @@ class TestFullSquadBuilderProfile:
         # so its presence is a deliberate fact rather than drift.
         profiles = await provider.list_profiles()
         ids = {p.profile_id for p in profiles}
-        assert ids == {"smoke", "lite", "full", "full-38"}
+        # full-38-atlas is arm B of the 1.7.0 Atlas A/B (#1160): the same roster with the
+        # model named as Atlas serves it. Inert until that deploy selects it.
+        assert ids == {"smoke", "lite", "full", "full-38", "full-38-atlas"}
 
 
 class TestFull38QaCompletionBudget:


### PR DESCRIPTION
## What

The pre-registration for #1160's artifact, and the two pieces of configuration the Atlas arm needs — nothing here changes which engine serves a token until the arm switch is run by hand.

- **`docs/plans/1-7-0-atlas-ab-preregistration.md`** — two *deploys*, per the owner's ruling of 2026-08-28: arm A is production Ollama untouched (`full-38`, `qwen3.8:27b` Q4_K_M); arm B is the best serve line the tuning pass found on the same Qwen3.8-27B. Order **A1, B1, B2, A2** on Next.js (the 6/6 stack, so verdict noise doesn't swamp the pair; second pair B-first to expose ordering effects), then **A3, B3** on FastAPI+React for correction texture; an Atlas shakeout first (also Appendix C.2's warm-up, recorded and flagged); engine isolation per arm; six mechanism predictions; the Appendix C amendments the artifact will record (C.1-1 superseded; `load_ms` → TTFT + flagged warm-up; corpus = cycles).
- **The tuning result** (full matrix on #1160): FP8 12.5 t/s → MTP speculative K=3 29.5 → **K=4 33.8** → K=5 23.0; NVFP4 12.8 and *also* dequantized in memory (58.5 GB) — no gain either way. Token counts identical across FP8 rows; all slots filled. Arm B: `--speculative --num-drafts 3 --enable-prefix-caching --scheduling-policy slai --kv-cache-dtype fp8`.
- **`config/squad-profiles.yaml`: `full-38-atlas`** — the `full-38` roster verbatim (incl. the eve override) with the model named the way Atlas serves it (`Qwen/Qwen3.8-27B-FP8`; SIP-0106 §3.4). Inert: nothing selects it. The squad-profile provider is `config`, so it goes live with a runtime-api rebuild — that rebuild is the frozen deploy for *both* arms.
- **`docker-compose.atlas.yml`** — an override layered on the base file (`-f docker-compose.yml -f docker-compose.atlas.yml`), never editing it: provider/url/model/api_key on the eight SquadOps services and the `atlas_api_key` secret (`secrets/atlas_api_key.txt`, gitignored). Verified to render on all eight with `docker compose config`. Plain `docker compose up -d` restores arm A. This is also the candidate mechanism for the switch (SIP-0106 §5).
- Four set files under `docs/plans/verification-sets/1-7-0-ab-*` for the driver (pins filled after the shakeout, the 1.6.6 pattern).

## Closes

Refs #1160 — remaining: the shakeout, the pairs, the record.
Refs #1158 — remaining: the `local-spark` bootstrap entry.

## Evidence

Docs and inert config. `validate_agent_entries(full-38-atlas)` → no errors; all four set files parse; `ATLAS_MODEL=… docker compose -f docker-compose.yml -f docker-compose.atlas.yml config` renders the four LLM vars on eight services and mounts the secret. Tuning data: #1160 (three comments, raw JSONL kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbzZWzB8VgjZdbtKX9N41L
