### PR TITLE
docs(plan): Atlas A/B pre-registration §1.2 — the content-loop watchdog cut long YAML; serve line adds --content-loop-watchdog false, --lm-head-dtype bf16 (#1160)

### DIFF
--- a/docs/plans/1-7-0-atlas-ab-preregistration.md
+++ b/docs/plans/1-7-0-atlas-ab-preregistration.md
@@ -13,7 +13,7 @@ configuration, stated in full**. The tuning pass that chose arm B is on #1160.
 |---|---|---|
 | squad profile | `full-38` | `full-38-atlas` — the same roster and eve override, model named as Atlas serves it |
 | model | `qwen3.8:27b`, **Q4_K_M** (Ollama's tag), 262K native window | `Qwen/Qwen3.8-27B-FP8`, **FP8 dequantized to BF16 in memory**, served window 32K |
-| engine | Ollama 0.32.14 as deployed; no tuning — every 1.6.x record sits on it | `avarok/atlas-gb10:latest` (built 2026-08-15), `serve Qwen/Qwen3.8-27B-FP8 --speculative --num-drafts 3 --enable-prefix-caching --scheduling-policy slai --kv-cache-dtype fp8 --max-seq-len 32768 --gpu-memory-utilization 0.75 --request-timeout 1800 --content-loop-watchdog false --lm-head-dtype bf16 --bind 0.0.0.0 --require-auth --auth-tokens-file … --no-auto-swap --no-tui` (`--request-timeout` added by §1.1; `--content-loop-watchdog false --lm-head-dtype bf16` by §1.2) |
+| engine | Ollama 0.32.14 as deployed; no tuning — every 1.6.x record sits on it | `avarok/atlas-gb10:latest` (built 2026-08-15), `serve Qwen/Qwen3.8-27B-FP8 --speculative --num-drafts 3 --enable-prefix-caching --scheduling-policy slai --max-seq-len 32768 --gpu-memory-utilization 0.75 --request-timeout 1800 --content-loop-watchdog false --lm-head-dtype bf16 --kv-cache-dtype bf16 --dump /dumps/atlas-requests.jsonl --bind 0.0.0.0 --require-auth --auth-tokens-file … --no-auto-swap --no-tui` (`--request-timeout` added by §1.1; `--content-loop-watchdog false --lm-head-dtype bf16` by §1.2; `--kv-cache-dtype bf16` replacing `fp8` and `--dump` by §1.3) |
 | why that serve line | — | the tuning matrix (#1160): FP8 12.5 t/s → MTP speculative K=3 29.5 → **K=4 33.8** → K=5 23.0 (over-drafting); NVFP4 12.8 and also dequantized (no memory or speed gain). Token counts identical across rows on the fill brief |
 | how the deploy is pointed at B | — | `docker compose -f docker-compose.yml -f docker-compose.atlas.yml up -d` (`ATLAS_MODEL=Qwen/Qwen3.8-27B-FP8`, secret `atlas_api_key`); back to A with plain `docker compose up -d`. Recreating the containers is also Appendix C.3's "restart the agent containers between arms" |
 | project / request profile | `group_run` / `validated-fullstack` | same |
@@ -58,6 +58,29 @@ measured cost). Both are server-side flags — the frozen deploy of §1.1 stands
 Ollama has no equivalent of either, so this is a serve-line difference between the arms, not
 a model one. **A third shakeout on arm B precedes B1.** The per-request evidence of both
 failed shakeouts and both gate runs is on #1160.
+
+### 1.3 Reading the rest of the serve defaults before the third shakeout (2026-08-29)
+
+Two failures from unread defaults prompted a full pass over the server's startup log,
+`--help`, the checkpoint's `generation_config.json` and Ollama's Modelfile:
+
+- **KV cache**: Atlas warned at every start that the checkpoint ships no `k_scale`/`v_scale`
+  tensors, so the FP8 KV cache used scale 1.0 — "silently clips BF16 into E4M3 range and
+  destroys dynamic range" — precisely where the ~17k-token qa briefs live. The model has 16
+  full-attention layers × 4 KV heads × 256 dims: BF16 KV is ~64 KB/token, ~2 GB per 32K
+  sequence, trivial under the 0.75 cap. **`--kv-cache-dtype bf16`** replaces `fp8`; no
+  calibration to get wrong.
+- **Sampling parity**: with no override the handlers send no sampling parameters, so each
+  engine's defaults apply. Both default to temperature 1, top-k 20, top-p 0.95, min-p 0 — the
+  1.6.x record ran at temperature 1 — and Atlas adds `top_n_sigma=1`, a logit filter it
+  recommends for agent workloads. Kept, as part of "best from Atlas"; stated here as an arm
+  difference.
+- **Behaviour defaults now known and set**: `thinking_default=true`, `max_thinking_budget=2048`
+  (`xhigh` = 4×), watchdog off (§1.2), MTP 3 drafts/step, prefix caching on, chunked prefill
+  8,192, `max_batch=8`.
+- **`--dump /dumps/atlas-requests.jsonl`**: every request and response on arm B, verbatim, to
+  a host-mounted file — the full-prompt store the record otherwise lacks (LangFuse caps
+  `input` at 10k chars). Arm A has no equivalent; the record says so.
 
 ## 2. Preconditions — all, or the numbers lie
 

--- a/docs/plans/1-7-0-atlas-ab-preregistration.md
+++ b/docs/plans/1-7-0-atlas-ab-preregistration.md
@@ -13,7 +13,7 @@ configuration, stated in full**. The tuning pass that chose arm B is on #1160.
 |---|---|---|
 | squad profile | `full-38` | `full-38-atlas` — the same roster and eve override, model named as Atlas serves it |
 | model | `qwen3.8:27b`, **Q4_K_M** (Ollama's tag), 262K native window | `Qwen/Qwen3.8-27B-FP8`, **FP8 dequantized to BF16 in memory**, served window 32K |
-| engine | Ollama 0.32.14 as deployed; no tuning — every 1.6.x record sits on it | `avarok/atlas-gb10:latest` (built 2026-08-15), `serve Qwen/Qwen3.8-27B-FP8 --speculative --num-drafts 3 --enable-prefix-caching --scheduling-policy slai --kv-cache-dtype fp8 --max-seq-len 32768 --gpu-memory-utilization 0.75 --request-timeout 1800 --bind 0.0.0.0 --require-auth --auth-tokens-file … --no-auto-swap --no-tui` (`--request-timeout` added by §1.1) |
+| engine | Ollama 0.32.14 as deployed; no tuning — every 1.6.x record sits on it | `avarok/atlas-gb10:latest` (built 2026-08-15), `serve Qwen/Qwen3.8-27B-FP8 --speculative --num-drafts 3 --enable-prefix-caching --scheduling-policy slai --kv-cache-dtype fp8 --max-seq-len 32768 --gpu-memory-utilization 0.75 --request-timeout 1800 --content-loop-watchdog false --lm-head-dtype bf16 --bind 0.0.0.0 --require-auth --auth-tokens-file … --no-auto-swap --no-tui` (`--request-timeout` added by §1.1; `--content-loop-watchdog false --lm-head-dtype bf16` by §1.2) |
 | why that serve line | — | the tuning matrix (#1160): FP8 12.5 t/s → MTP speculative K=3 29.5 → **K=4 33.8** → K=5 23.0 (over-drafting); NVFP4 12.8 and also dequantized (no memory or speed gain). Token counts identical across rows on the fill brief |
 | how the deploy is pointed at B | — | `docker compose -f docker-compose.yml -f docker-compose.atlas.yml up -d` (`ATLAS_MODEL=Qwen/Qwen3.8-27B-FP8`, secret `atlas_api_key`); back to A with plain `docker compose up -d`. Recreating the containers is also Appendix C.3's "restart the agent containers between arms" |
 | project / request profile | `group_run` / `validated-fullstack` | same |
@@ -40,6 +40,24 @@ runtime-api images are rebuilt on that commit, which becomes the frozen deploy; 
 shakeout on arm B precedes B1**, recorded and flagged like the first. The `high → xhigh`
 mapping stands. Nothing else in §1 changes. The failed shakeout's per-request evidence is
 on #1160 and stays in the record as the warm-up that found this.
+
+### 1.2 Revision after the second shakeout (2026-08-28, `cyc_6db3a5d8d1ca`, failed)
+
+The second Atlas cycle, on the rebuilt deploy with `--request-timeout 1800`, got through the
+brief (no generation was cut) and failed at `governance.merge_plan`: eight attempts, every
+one an `implementation_plan.yaml` that failed validation, 3–5k-token emissions all reporting
+`stop`. The vendor's own long-generation gate (a ~3k-token YAML plan at `xhigh`, parsed)
+found the cause in Atlas's log: **the content-loop watchdog** — "period-2…64 repetition
+detector", which its `--help` says can false-positive on code and tables — fired on the
+legitimate repetition of a YAML task list and ended the emission mid-document (2,727 tokens,
+`finish_reason: length`, no fence). With `--content-loop-watchdog false` the same gate parsed
+4 of 4 plans clean (4.2–7.9k tokens) on both the default (NVFP4) and BF16 lm-head, at the same
+decode rate. **Revision:** the serve line adds `--content-loop-watchdog false` and
+`--lm-head-dtype bf16` (the vendor's stated safe choice for long structured generation; no
+measured cost). Both are server-side flags — the frozen deploy of §1.1 stands unchanged — and
+Ollama has no equivalent of either, so this is a serve-line difference between the arms, not
+a model one. **A third shakeout on arm B precedes B1.** The per-request evidence of both
+failed shakeouts and both gate runs is on #1160.
 
 ## 2. Preconditions — all, or the numbers lie
 


### PR DESCRIPTION
## What

Shakeout #2 (`cyc_6db3a5d8d1ca`, on the rebuilt deploy with `--request-timeout 1800`) passed the brief and failed at `governance.merge_plan` — 8/8 malformed `implementation_plan.yaml`, all `stop`. The vendor's own prescribed gate (a ~3k-token YAML plan at `xhigh`, parsed) found it in Atlas's log: **"Content-loop watchdog fired in MTP/emit path (period-2…64 repeat); ending response"** — the repetition detector firing on a YAML task list and cutting the document mid-emission (2,727 tokens, no fence). With `--content-loop-watchdog false`: 4/4 plans parsed clean (4.2–7.9k tokens) on both NVFP4 and BF16 lm-heads, same decode rate.

§1.2 records the finding and adds `--content-loop-watchdog false` and `--lm-head-dtype bf16` (the vendor's stated safe choice for long structured generation) to arm B's serve line. Server-side only: the frozen deploy from §1.1 stands; Ollama has no equivalent of either flag. A third arm-B shakeout precedes B1. Evidence on #1160 (gate runs 1 and 2).


**§1.3 (second commit) — the rest of the serve defaults, read before the third shakeout:** Atlas warned at every start that the checkpoint ships no `k_scale`/`v_scale`, so the FP8 KV cache used scale 1.0 and "silently clips BF16 into E4M3 range" — right where the ~17k-token qa briefs live. 16 full-attention layers × 4 KV heads × 256 dims = ~2 GB per 32K sequence at BF16, so **`--kv-cache-dtype bf16`** replaces `fp8` outright. Sampling parity checked and stated (both engines default to temperature 1 / top-k 20 / top-p 0.95 / min-p 0; Atlas adds its recommended `top_n_sigma=1`). **`--dump`** records every arm-B request and response verbatim to a host-mounted file — the full-prompt store the record otherwise lacks. Behaviour defaults enumerated from the startup log.

## Closes

Refs #1160 — remaining: the third shakeout, the pairs, the record.

## Evidence

Docs only; `tests/unit/architecture` green. Gate rows on #1160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbzZWzB8VgjZdbtKX9N41L

