### PR TITLE
fix(llm): the Atlas arm's served window covers its own prompts — 32K left the prompt guard 24,576 tokens (#1160 §1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@ All notable changes to SquadOps are recorded here. Format loosely follows
   served Qwen3.8 template requires; streamed `reasoning_content` deltas never reach the
   text. Registered as the conformance suite's third case, with the measured shapes.
 - `ChatMessage` / `LLMResponse` gain `reasoning_tokens` (None when not reported, never
-  zero); `Qwen/Qwen3.8-27B-FP8` joins the model registry with the served 32K window.
+  zero); `Qwen/Qwen3.8-27B-FP8` joins the model registry with the window the A/B recipe
+  serves — 64K, raised from the first recipe's 32K because that left the prompt guard a
+  24,576-token budget and 5.9% of the arm's real prompts run longer (#1160 §1.4).
 
 ### Added — reasoning is a level on the port (#927)
 - **The port carries `reasoning: none | low | medium | high`**, never a provider's

--- a/docs/plans/1-7-0-atlas-ab-preregistration.md
+++ b/docs/plans/1-7-0-atlas-ab-preregistration.md
@@ -12,8 +12,8 @@ configuration, stated in full**. The tuning pass that chose arm B is on #1160.
 | | Arm A — Ollama (production, untouched) | Arm B — Atlas (tuned) |
 |---|---|---|
 | squad profile | `full-38` | `full-38-atlas` — the same roster and eve override, model named as Atlas serves it |
-| model | `qwen3.8:27b`, **Q4_K_M** (Ollama's tag), 262K native window | `Qwen/Qwen3.8-27B-FP8`, **FP8 dequantized to BF16 in memory**, served window 32K |
-| engine | Ollama 0.32.14 as deployed; no tuning — every 1.6.x record sits on it | `avarok/atlas-gb10:latest` (built 2026-08-15), `serve Qwen/Qwen3.8-27B-FP8 --speculative --num-drafts 3 --enable-prefix-caching --scheduling-policy slai --max-seq-len 32768 --gpu-memory-utilization 0.75 --request-timeout 1800 --content-loop-watchdog false --lm-head-dtype bf16 --kv-cache-dtype bf16 --dump /dumps/atlas-requests.jsonl --bind 0.0.0.0 --require-auth --auth-tokens-file … --no-auto-swap --no-tui` (`--request-timeout` added by §1.1; `--content-loop-watchdog false --lm-head-dtype bf16` by §1.2; `--kv-cache-dtype bf16` replacing `fp8` and `--dump` by §1.3) |
+| model | `qwen3.8:27b`, **Q4_K_M** (Ollama's tag), 262K native window | `Qwen/Qwen3.8-27B-FP8`, **FP8 dequantized to BF16 in memory**, served window 64K (§1.4) |
+| engine | Ollama 0.32.14 as deployed; no tuning — every 1.6.x record sits on it | `avarok/atlas-gb10:latest` (built 2026-08-15), `serve Qwen/Qwen3.8-27B-FP8 --speculative --num-drafts 3 --enable-prefix-caching --scheduling-policy slai --max-seq-len 65536 --gpu-memory-utilization 0.75 --request-timeout 1800 --content-loop-watchdog false --lm-head-dtype bf16 --kv-cache-dtype bf16 --dump /dumps/atlas-requests.jsonl --bind 0.0.0.0 --require-auth --auth-tokens-file … --no-auto-swap --no-tui` (`--request-timeout` added by §1.1; `--content-loop-watchdog false --lm-head-dtype bf16` by §1.2; `--kv-cache-dtype bf16` replacing `fp8` and `--dump` by §1.3; `--max-seq-len` raised from `32768` by §1.4) |
 | why that serve line | — | the tuning matrix (#1160): FP8 12.5 t/s → MTP speculative K=3 29.5 → **K=4 33.8** → K=5 23.0 (over-drafting); NVFP4 12.8 and also dequantized (no memory or speed gain). Token counts identical across rows on the fill brief |
 | how the deploy is pointed at B | — | `docker compose -f docker-compose.yml -f docker-compose.atlas.yml up -d` (`ATLAS_MODEL=Qwen/Qwen3.8-27B-FP8`, secret `atlas_api_key`); back to A with plain `docker compose up -d`. Recreating the containers is also Appendix C.3's "restart the agent containers between arms" |
 | project / request profile | `group_run` / `validated-fullstack` | same |
@@ -81,6 +81,43 @@ Two failures from unread defaults prompted a full pass over the server's startup
 - **`--dump /dumps/atlas-requests.jsonl`**: every request and response on arm B, verbatim, to
   a host-mounted file — the full-prompt store the record otherwise lacks (LangFuse caps
   `input` at 10k chars). Arm A has no equivalent; the record says so.
+
+### 1.4 The served window, read against the arm's own prompts (2026-08-29)
+
+The third revision from an unread serve default, and the first that would not have failed
+loudly. `--max-seq-len 32768` was the first-serve recipe's number (#1158), carried into the
+registry entry the prompt guard reads. The guard spends `context_window −
+max_completion_tokens` on the prompt: **24,576 usable prompt tokens on arm B** against
+**253,952 on arm A** (`qwen3.8:27b`, 262,144 − 8,192). Over budget it does not fail — it
+deletes the `## Prior Analysis from Upstream Roles` section and sends the rest
+(`src/squadops/capabilities/handlers/prompt_guard.py`), raising
+`PROMPT_EXCEEDS_CONTEXT_WINDOW` only if the remainder still will not fit. Framing prompts
+never reach the guard at all (its only callers are the dev and qa handlers) and would have
+met the server's limit directly, as in §1.1.
+
+What this arm's prompts actually are — Ollama's own `new prompt` lines for the 27B,
+n = 1,145 since 2026-08-22, `n_ctx_slot = 262144`:
+
+| median | p90 | p99 | max | > 24,576 | > 32,768 |
+|---|---|---|---|---|---|
+| 9,895 | 20,212 | 31,137 | 38,210 | ~5.9% | 0.87% |
+
+Roughly **one generation in seventeen** would have run on arm B with its upstream analysis
+deleted and on arm A intact — a difference in what the model was asked, invisible in the
+verdict, that the record would have credited to the engine. **Revision:** `--max-seq-len
+65536` on the serve line and `context_window=65_536` on the registry entry; 38,210 plus the
+8,192 completion clamp fits with headroom. The KV pool is paged and sized independently of
+the cap (16.2 GB ≈ 265K tokens at ~64 KB/token BF16), so one 64K sequence costs ~4 GB of it
+and nothing at the observed median. Arm A is untouched — and its 262,144 is the *served*
+window, not just the checkpoint's claim: every 27B load in the Ollama server log reports
+`n_ctx = 262144`. The registry entry ships in the images, so **the agent and runtime-api
+images are rebuilt on this commit and that rebuild is the frozen deploy** (superseding
+§1.1's, whose ids the §1 table still named); the ids are pinned in the set files before the
+first counting roll. The third shakeout runs on this line.
+
+Whether Atlas rejects or silently truncates past its window is asserted in the registry
+comment but has never been measured. One over-window request is probed before the shakeout
+and the answer recorded here.
 
 ## 2. Preconditions — all, or the numbers lie
 

--- a/docs/plans/1-7-0-atlas-ab-preregistration.md
+++ b/docs/plans/1-7-0-atlas-ab-preregistration.md
@@ -115,9 +115,18 @@ images are rebuilt on this commit and that rebuild is the frozen deploy** (super
 §1.1's, whose ids the §1 table still named); the ids are pinned in the set files before the
 first counting roll. The third shakeout runs on this line.
 
-Whether Atlas rejects or silently truncates past its window is asserted in the registry
-comment but has never been measured. One over-window request is probed before the shakeout
-and the answer recorded here.
+**Probed on this serve line, 2026-08-29, before the shakeout.** Atlas *rejects* past its
+window, it does not truncate — the registry comment's assertion is now a measurement: a
+69,668-token prompt returns `400 invalid_request_error`, *"Prompt too long: 69668 tokens
+exceeds max_seq_len 65536 (leave room for output tokens)"*, in 0.1 s. Below the cap it
+serves what the old line would have cut: 7,642 tokens → 200 in 13.2 s; **37,836 tokens →
+200 in 55.3 s** — over the old 32,768 cap and half again the old guard's 24,576 budget. The
+server's arithmetic is the guard's: prompt plus output must fit `max_seq_len`, which is what
+reserving `default_max_completion` inside `context_window` produces. Two readings for the
+record: prefill runs ~600–700 tok/s, so a 38K prompt costs ~55 s before the first token on
+arm B — that belongs to P2's wall-clock, not to a failure; and at 65,536 the KV pool reports
+16.8 GB → 274,656 tokens (17,166 blocks × 16 tok/block), so one full-length sequence is ~24%
+of it and the only cap-scaled cost is a 355 MB chunked-prefill reserve.
 
 ## 2. Preconditions — all, or the numbers lie
 

--- a/src/squadops/llm/model_registry.py
+++ b/src/squadops/llm/model_registry.py
@@ -91,12 +91,19 @@ MODEL_SPECS: dict[str, ModelSpec] = {
     ),
     # Atlas serves models by HuggingFace path, so the same weights carry a second name
     # (SIP-0106 §3.4 — model identity is provider-scoped). The window is the one the
-    # local-spark recipe serves (`--max-seq-len 32768`, #1158), not the checkpoint's
-    # native 262K: Atlas rejects a prompt past the served window, and the prompt-size
-    # guard reads this number. The completion clamp matches the Ollama entry above.
+    # A/B recipe serves (`--max-seq-len 65536`), not the checkpoint's native 262K:
+    # Atlas rejects a prompt past the served window, and the prompt-size guard reads
+    # this number. 65,536 replaces the first recipe's 32,768 (#1158) because that
+    # window minus the 8,192 completion clamp leaves 24,576 usable prompt tokens, and
+    # 5.9% of this model's real prompts are longer than that — 1,145 prompts measured
+    # off the Ollama arm's own server log (median 9,895, p90 20,212, p99 31,137, max
+    # 38,210). Under 32,768 the guard would strip the prior-analysis section from
+    # roughly one generation in seventeen on the Atlas arm and none on the Ollama arm
+    # (`capabilities/handlers/prompt_guard.py`), which decides an engine comparison by
+    # the serve line. #1160 §1.4. The completion clamp matches the Ollama entry above.
     "Qwen/Qwen3.8-27B-FP8": ModelSpec(
         name="Qwen/Qwen3.8-27B-FP8",
-        context_window=32_768,
+        context_window=65_536,
         default_max_completion=8_192,
         reasoning_control=ReasoningControl.TOGGLE,
     ),

--- a/tests/unit/llm/test_model_registry.py
+++ b/tests/unit/llm/test_model_registry.py
@@ -40,8 +40,19 @@ class TestModelSpec:
         reasoning level (the channel stays on) and the prompt guard has no window —
         and the window must be the served one, since Atlas rejects prompts past it."""
         spec = MODEL_SPECS["Qwen/Qwen3.8-27B-FP8"]
-        assert spec.context_window == 32_768
+        assert spec.context_window == 65_536
         assert spec.default_max_completion == MODEL_SPECS["qwen3.8:27b"].default_max_completion
+
+    def test_the_atlas_windows_prompt_budget_covers_the_measured_prompts(self):
+        """The guard spends ``context_window - default_max_completion`` on the prompt
+        and silently drops the prior-analysis section above it (prompt_guard). The
+        longest real prompt measured on these weights is 38,210 tokens (#1160 §1.4,
+        n=1,145 off the Ollama arm), so a budget below that truncates the Atlas arm
+        where the Ollama arm — same weights, 262K served — is never truncated, and
+        the A/B reads a serve-line difference as an engine difference. The first
+        recipe's 32,768 failed this by 13,634 tokens."""
+        spec = MODEL_SPECS["Qwen/Qwen3.8-27B-FP8"]
+        assert spec.context_window - spec.default_max_completion >= 38_210
 
     def test_all_specs_context_exceeds_completion(self):
         """Every registered model must have context_window > default_max_completion."""


### PR DESCRIPTION
## What

Raises the Atlas arm's served window from 32,768 to 65,536 — on the serve line
(`--max-seq-len`) and on the `Qwen/Qwen3.8-27B-FP8` registry entry the prompt guard
reads — before the third A/B shakeout.

## Why

The prompt guard spends `context_window - max_completion_tokens` on the prompt
(`src/squadops/capabilities/handlers/prompt_guard.py`). Over budget it does not fail: it
deletes the `## Prior Analysis from Upstream Roles` section and sends the rest, raising
`PROMPT_EXCEEDS_CONTEXT_WINDOW` only if the remainder still will not fit. At
`--max-seq-len 32768` that budget was **24,576 tokens on arm B** against **253,952 on
arm A** — the same weights, served by Ollama at its native 262,144.

Measured off the Ollama arm's own server log (1,145 prompts on `qwen3.8:27b` since
2026-08-22, `n_ctx_slot = 262144`):

| median | p90 | p99 | max | > 24,576 | > 32,768 |
|---|---|---|---|---|---|
| 9,895 | 20,212 | 31,137 | 38,210 | ~5.9% | 0.87% |

So roughly **one generation in seventeen** would have run on arm B with its upstream
analysis removed and on arm A intact — a difference in what the model was asked,
invisible in the verdict, that the record would have credited to the engine. Framing
prompts never reach the guard at all (its only callers are the dev and qa handlers) and
would have met the server's limit directly, which is how §1.1 failed.

65,536 covers the longest observed prompt (38,210) plus the 8,192 completion clamp with
headroom. The KV pool is paged and sized independently of the cap (16.2 GB ≈ 265K tokens
at ~64 KB/token BF16), so one 64K sequence costs ~4 GB of it and nothing at the observed
median. Arm A is untouched.

## Changes

- `src/squadops/llm/model_registry.py` — `context_window` 32,768 → 65,536, with the
  measurement in the comment
- `tests/unit/llm/test_model_registry.py` — the pinned window follows, plus a new guard
  that the usable prompt budget covers the longest measured real prompt
- `docs/plans/1-7-0-atlas-ab-preregistration.md` — §1.4 records the revision and the
  distribution; the §1 table's serve line and window cell follow
- `CHANGELOG.md` — the registry line names the served window it now carries
- (outside the repo) `~/atlas/scripts/atlas_serve.sh` raises `--max-seq-len` to match

## Consequence for the A/B

The registry entry ships in the images, so the agent and runtime-api rebuild on this
commit becomes the frozen deploy — superseding §1.1's, whose ids the §1 table still
named. Those ids are pinned into the four set files before the first counting roll. The
third shakeout runs on this line.

Whether Atlas rejects or silently truncates past its window is asserted in the registry
comment but has never been measured; one over-window request is probed before the
shakeout and the answer recorded in §1.4.

## Tests

`tests/unit/llm/` + `tests/unit/architecture/` — 234 passed; prompt-guard tests — 20
passed; ruff clean.

Refs #1160 — remaining: the A/B itself (shakeout #3, the A1/B1/B2/A2 and A3/B3 rolls,
and the record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmZK2pNuaiXuzNqGrtL27h