### PR TITLE
fix: the framing half of a cycle is observable and correctly budgeted — one seam for generation records, per-attempt manifest telemetry, and a completion budget that accounts for declared thinking

### DIFF
--- a/adapters/comms/chat_executor.py
+++ b/adapters/comms/chat_executor.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import logging
 import time
-import uuid
 from typing import TYPE_CHECKING
 
 from a2a.server.agent_execution import AgentExecutor, RequestContext
@@ -265,9 +264,9 @@ class ChatAgentExecutor(AgentExecutor):
         try:
             from squadops.telemetry.models import (
                 CorrelationContext,
-                GenerationRecord,
                 PromptLayer,
                 PromptLayerMetadata,
+                build_generation_record,
             )
 
             ctx = CorrelationContext(
@@ -276,8 +275,9 @@ class ChatAgentExecutor(AgentExecutor):
                 agent_id=self._role_id,
                 agent_role=self._role_id,
             )
-            record = GenerationRecord(
-                generation_id=str(uuid.uuid4()),
+            # usage=None: this recorder is handed text and a latency by its caller,
+            # never the response object, so there are no token counts to report here.
+            record = build_generation_record(
                 model=self._ports.llm.default_model,
                 prompt_text=prompt_text,
                 response_text=response_text,

--- a/adapters/telemetry/langfuse/adapter.py
+++ b/adapters/telemetry/langfuse/adapter.py
@@ -432,6 +432,8 @@ class LangFuseAdapter(LLMObservabilityPort):
                     "latency_ms": record.latency_ms,
                     "tokens_per_second": record.tokens_per_second,
                     "reasoning": record.reasoning,
+                    "attempt": record.attempt,
+                    "outcome": record.outcome,
                     "prompt_layer_set_id": prompt_layers.prompt_layer_set_id,
                     "prompt_layers": [
                         {

--- a/src/squadops/agents/entrypoint.py
+++ b/src/squadops/agents/entrypoint.py
@@ -641,7 +641,6 @@ class AgentRunner:
             # Generate response using the LLM
             if self.system and self.system.ports.llm:
                 import time
-                import uuid
 
                 from squadops.llm.models import LLMRequest
 
@@ -663,9 +662,9 @@ class AgentRunner:
                 if llm_obs is not None:
                     from squadops.telemetry.models import (
                         CorrelationContext,
-                        GenerationRecord,
                         PromptLayer,
                         PromptLayerMetadata,
+                        build_generation_record,
                     )
 
                     ctx = CorrelationContext(
@@ -674,12 +673,12 @@ class AgentRunner:
                         agent_id=self.agent_id,
                         agent_role=self.role,
                     )
-                    record = GenerationRecord(
-                        generation_id=str(uuid.uuid4()),
+                    record = build_generation_record(
                         model=self._llm_model,
                         prompt_text=full_prompt,
                         response_text=response_text,
                         latency_ms=latency_ms,
+                        usage=response,
                     )
                     layers = PromptLayerMetadata(
                         prompt_layer_set_id=f"{self.role}-chat",

--- a/src/squadops/capabilities/handlers/_plan_authoring_service.py
+++ b/src/squadops/capabilities/handlers/_plan_authoring_service.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import re
+import time
 from typing import TYPE_CHECKING, Any
 
 from squadops.capabilities.handlers._plan_authoring import (
@@ -256,6 +257,7 @@ async def produce_plan(
     ]
 
     for attempt in range(1, max_attempts + 1):
+        started = time.perf_counter()
         try:
             response = await context.ports.llm.chat_stream_with_usage(messages, **chat_kwargs)
         except Exception as exc:
@@ -281,6 +283,17 @@ async def produce_plan(
 
         manifest, error_msg = _validate_manifest_candidate(
             yaml_content, min_subtasks, max_subtasks, profile_roles
+        )
+        _record_manifest_attempt(
+            context,
+            handler_name=handler_name,
+            model=chat_kwargs.get("model"),
+            prompt_text=messages[-1].content,
+            response=response,
+            latency_ms=(time.perf_counter() - started) * 1000,
+            attempt=attempt,
+            outcome="accepted" if error_msg is None else error_msg,
+            reasoning=chat_kwargs.get("reasoning"),
         )
 
         if error_msg is None and manifest is not None:
@@ -327,6 +340,63 @@ async def produce_plan(
         ]
 
     return None
+
+
+def _record_manifest_attempt(
+    context: Any,
+    *,
+    handler_name: str,
+    model: str | None,
+    prompt_text: str,
+    response: Any,
+    latency_ms: float,
+    attempt: int,
+    outcome: str,
+    reasoning: str | None,
+) -> None:
+    """Record one manifest attempt as a generation (#1172).
+
+    This path had no telemetry at all: `merge_plan` called the LLM and emitted
+    nothing, so the capability that decides whether a cycle can start building was
+    the one capability LangFuse could not see. Diagnosing its failures needed the
+    engine's own request dump and `docker logs` on the lead agent — neither of which
+    survives a rebuild.
+
+    One record per attempt, not a roll-up: the repair loop is the diagnostic object.
+    The prompt recorded is the user turn that produced this generation, which on a
+    repair round is the validator's complaint rather than the original brief.
+    Best-effort — observability must never fail an authoring run.
+    """
+    llm_obs = getattr(context.ports, "llm_observability", None)
+    if not llm_obs or not getattr(context, "correlation_context", None):
+        return
+    try:
+        from squadops.telemetry.models import (
+            PromptLayer,
+            PromptLayerMetadata,
+            build_generation_record,
+        )
+
+        record = build_generation_record(
+            model=model or context.ports.llm.default_model,
+            prompt_text=prompt_text,
+            response_text=getattr(response, "content", "") or "",
+            latency_ms=latency_ms,
+            usage=response,
+            reasoning=reasoning,
+            attempt=attempt,
+            outcome=outcome,
+        )
+        layers = PromptLayerMetadata(
+            prompt_layer_set_id="lead-plan-authoring",
+            layers=(
+                PromptLayer(layer_type="system", layer_id="governance-review-plan-manifest-system"),
+                PromptLayer(layer_type="user", layer_id="request.governance_review_plan_manifest"),
+            ),
+        )
+        llm_obs.record_generation(context.correlation_context, record, layers)
+    except Exception:  # pragma: no cover - best effort
+        logger.debug("%s: manifest generation not recorded", handler_name, exc_info=True)
 
 
 def _build_manifest_user_prompt_inline(v: dict[str, str]) -> str:

--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -716,26 +716,19 @@ class _CycleTaskHandler(CapabilityHandler):
         # Record LLM generation for LangFuse tracing (SIP-0061 Option B)
         llm_obs = getattr(context.ports, "llm_observability", None)
         if llm_obs and context.correlation_context:
-            import uuid
-
             from squadops.telemetry.models import (
-                MAX_OBSERVABILITY_TEXT_LENGTH,
-                GenerationRecord,
                 PromptLayer,
                 PromptLayerMetadata,
+                build_generation_record,
             )
 
             resolved_model = chat_kwargs.get("model", context.ports.llm.default_model)
-            gen_record = GenerationRecord(
-                generation_id=str(uuid.uuid4()),
+            gen_record = build_generation_record(
                 model=resolved_model,
-                prompt_text=user_prompt[:MAX_OBSERVABILITY_TEXT_LENGTH],
-                response_text=content[:MAX_OBSERVABILITY_TEXT_LENGTH],
+                prompt_text=user_prompt,
+                response_text=content,
                 latency_ms=llm_duration_ms,
-                tokens_per_second=response.tokens_per_second,
-                prompt_tokens=response.prompt_tokens,
-                completion_tokens=response.completion_tokens,
-                total_tokens=response.total_tokens,
+                usage=response,
                 prompt_name=rendered.template_id if rendered else None,
                 prompt_version=(
                     int(rendered.template_version)
@@ -893,25 +886,18 @@ class _CycleTaskHandler(CapabilityHandler):
             )
         llm_obs = getattr(context.ports, "llm_observability", None)
         if llm_obs and context.correlation_context:
-            import uuid
-
             from squadops.telemetry.models import (
-                MAX_OBSERVABILITY_TEXT_LENGTH,
-                GenerationRecord,
                 PromptLayer,
                 PromptLayerMetadata,
+                build_generation_record,
             )
 
-            gen_record = GenerationRecord(
-                generation_id=str(uuid.uuid4()),
+            gen_record = build_generation_record(
                 model=resolved_model or context.ports.llm.default_model,
-                prompt_text=prompt[:MAX_OBSERVABILITY_TEXT_LENGTH],
-                response_text=response[:MAX_OBSERVABILITY_TEXT_LENGTH],
+                prompt_text=prompt,
+                response_text=response,
                 latency_ms=duration_ms,
-                tokens_per_second=(chat_response.tokens_per_second if chat_response else None),
-                prompt_tokens=chat_response.prompt_tokens if chat_response else None,
-                completion_tokens=(chat_response.completion_tokens if chat_response else None),
-                total_tokens=chat_response.total_tokens if chat_response else None,
+                usage=chat_response,
                 prompt_name=getattr(rendered, "template_id", None),
                 prompt_version=(
                     int(rendered.template_version)

--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -355,7 +355,8 @@ class _CycleTaskHandler(CapabilityHandler):
         max_tokens += thinking_headroom(
             resolve_reasoning_level(
                 self._capability_id, agent_overrides=agent_overrides, model_name=agent_model
-            )
+            ),
+            model_spec,
         )
         if "max_completion_tokens" in agent_overrides:
             max_tokens = agent_overrides["max_completion_tokens"]
@@ -392,7 +393,7 @@ class _CycleTaskHandler(CapabilityHandler):
             # #1173: output budget plus room for the declared thinking. These two were
             # computed four lines apart and never combined, so a HIGH capability paid
             # for its reasoning out of the document's allowance.
-            kwargs["max_tokens"] = spec.default_max_completion + thinking_headroom(reasoning)
+            kwargs["max_tokens"] = spec.default_max_completion + thinking_headroom(reasoning, spec)
         if "timeout_seconds" in overrides:
             kwargs["timeout_seconds"] = overrides["timeout_seconds"]
         if reasoning is not None:

--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -32,7 +32,7 @@ from squadops.cycles.implementation_plan import TypedCheck
 from squadops.cycles.patch_verification import materialize_artifacts
 from squadops.cycles.verification_integrity import ResultStatus
 from squadops.llm.exceptions import LLMError
-from squadops.llm.model_registry import get_model_spec
+from squadops.llm.model_registry import get_model_spec, thinking_headroom
 from squadops.llm.models import ChatMessage
 
 if TYPE_CHECKING:
@@ -349,6 +349,14 @@ class _CycleTaskHandler(CapabilityHandler):
         if model_spec is not None:
             max_tokens = min(max_tokens, model_spec.default_max_completion)
             context_window = model_spec.context_window
+        # #1173: the clamp above is an OUTPUT budget; thinking is billed against the
+        # same wire budget and the framework discards it. Add room for the level this
+        # capability declared, so declaring HIGH does not silently shrink the answer.
+        max_tokens += thinking_headroom(
+            resolve_reasoning_level(
+                self._capability_id, agent_overrides=agent_overrides, model_name=agent_model
+            )
+        )
         if "max_completion_tokens" in agent_overrides:
             max_tokens = agent_overrides["max_completion_tokens"]
 
@@ -373,17 +381,20 @@ class _CycleTaskHandler(CapabilityHandler):
             kwargs["model"] = agent_model
         if "temperature" in overrides:
             kwargs["temperature"] = overrides["temperature"]
-        if "max_completion_tokens" in overrides:
-            kwargs["max_tokens"] = overrides["max_completion_tokens"]
-        elif agent_model and (spec := get_model_spec(agent_model)) is not None:
-            kwargs["max_tokens"] = spec.default_max_completion
-        if "timeout_seconds" in overrides:
-            kwargs["timeout_seconds"] = overrides["timeout_seconds"]
         # #927: keyed on the agent's model exactly as the completion clamp is — a
         # task dispatched without one sends no level, as it gets no clamp.
         reasoning = resolve_reasoning_level(
             self._capability_id, agent_overrides=overrides, model_name=agent_model
         )
+        if "max_completion_tokens" in overrides:
+            kwargs["max_tokens"] = overrides["max_completion_tokens"]
+        elif agent_model and (spec := get_model_spec(agent_model)) is not None:
+            # #1173: output budget plus room for the declared thinking. These two were
+            # computed four lines apart and never combined, so a HIGH capability paid
+            # for its reasoning out of the document's allowance.
+            kwargs["max_tokens"] = spec.default_max_completion + thinking_headroom(reasoning)
+        if "timeout_seconds" in overrides:
+            kwargs["timeout_seconds"] = overrides["timeout_seconds"]
         if reasoning is not None:
             kwargs["reasoning"] = reasoning
         return kwargs

--- a/src/squadops/capabilities/handlers/planning/base.py
+++ b/src/squadops/capabilities/handlers/planning/base.py
@@ -277,22 +277,19 @@ class _PlanningTaskHandler(_CycleTaskHandler):
         # Record LLM generation for LangFuse tracing (SIP-0061 Option B)
         llm_obs = getattr(context.ports, "llm_observability", None)
         if llm_obs and context.correlation_context:
-            import uuid
-
             from squadops.telemetry.models import (
-                MAX_OBSERVABILITY_TEXT_LENGTH,
-                GenerationRecord,
                 PromptLayer,
                 PromptLayerMetadata,
+                build_generation_record,
             )
 
             resolved_model = chat_kwargs.get("model", context.ports.llm.default_model)
-            gen_record = GenerationRecord(
-                generation_id=str(uuid.uuid4()),
+            gen_record = build_generation_record(
                 model=resolved_model,
-                prompt_text=user_prompt[:MAX_OBSERVABILITY_TEXT_LENGTH],
-                response_text=content[:MAX_OBSERVABILITY_TEXT_LENGTH],
+                prompt_text=user_prompt,
+                response_text=content,
                 latency_ms=llm_duration_ms,
+                usage=response,
                 prompt_name=rendered.template_id if rendered else None,
                 prompt_version=(
                     int(rendered.template_version)

--- a/src/squadops/llm/model_registry.py
+++ b/src/squadops/llm/model_registry.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from squadops.llm.models import ReasoningLevel
+
 
 class ReasoningControl:
     """Which reasoning dial a model exposes — a model fact, not a provider one (#927).
@@ -114,6 +116,44 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         reasoning_control=ReasoningControl.NONE,
     ),
 }
+
+
+#: Tokens to add to a capability's output budget for the thinking it declared.
+#:
+#: ``default_max_completion`` is a budget for OUTPUT — the registry comment records
+#: its basis as wall-clock ("qwen3.6:27b at ~10 t/s takes ~13 min for 8K tokens"),
+#: not document size. But thinking is billed against the same wire budget, so a
+#: capability that declares a reasoning level spends part of its output allowance
+#: on text the framework discards: adapters skip the thinking channel and nothing
+#: in the tree consumes it.
+#:
+#: Measured 2026-08-29 (#1173), replaying a real ``governance.merge_plan`` prompt
+#: three times on the production arm: a complete plan needs ~3,400 output tokens,
+#: and thinking at ``HIGH`` cost 4,500 / 6,100 / 7,600 tokens. Against a flat 8,192
+#: only the first fit — the capability succeeded one attempt in three, and the
+#: handler's retry loop hid that behind an eventual success.
+#:
+#: The headroom is added to the output budget rather than carved out of it, so a
+#: capability declared ``NONE`` is unaffected and one declared ``HIGH`` gets room
+#: to think *and* answer.
+THINKING_HEADROOM_TOKENS: dict[str, int] = {
+    ReasoningLevel.NONE: 0,
+    ReasoningLevel.LOW: 1_024,
+    ReasoningLevel.MEDIUM: 2_048,
+    ReasoningLevel.HIGH: 6_144,
+}
+
+
+def thinking_headroom(reasoning: str | None) -> int:
+    """Extra completion tokens for the reasoning level ``reasoning`` declares.
+
+    ``None`` — no level sent, so the wire is what it was before #927 — gets none.
+    An unknown level gets none rather than guessing: a level this table has not
+    been told about should show up as the old behaviour, not as a silent budget.
+    """
+    if reasoning is None:
+        return 0
+    return THINKING_HEADROOM_TOKENS.get(reasoning, 0)
 
 
 def get_model_spec(name: str) -> ModelSpec | None:

--- a/src/squadops/llm/model_registry.py
+++ b/src/squadops/llm/model_registry.py
@@ -144,15 +144,30 @@ THINKING_HEADROOM_TOKENS: dict[str, int] = {
 }
 
 
-def thinking_headroom(reasoning: str | None) -> int:
-    """Extra completion tokens for the reasoning level ``reasoning`` declares.
+def thinking_headroom(reasoning: str | None, spec: ModelSpec | None = None) -> int:
+    """Extra completion tokens for the reasoning ``reasoning`` will actually buy.
 
-    ``None`` — no level sent, so the wire is what it was before #927 — gets none.
-    An unknown level gets none rather than guessing: a level this table has not
-    been told about should show up as the old behaviour, not as a silent budget.
+    Keyed on what the *model* will do, not on what the capability declared. On a
+    ``TOGGLE`` model the two are different: the adapter maps every graded level to
+    a single boolean (``OllamaAdapter``: ``think = reasoning != NONE``), so a
+    capability declared MEDIUM thinks exactly as long as one declared HIGH and must
+    be budgeted the same. Keying on the declaration would under-budget every MEDIUM
+    capability on the production arm — ``development.develop`` foremost — in the way
+    #1173 was filed about.
+
+    ``None`` — no level sent, so the wire is what it was before #927 — gets none, as
+    does a level this table has not been told about: unknown means the old
+    behaviour, not a silently invented budget. A ``spec`` is optional so a caller
+    without one keeps the declared-level reading.
     """
     if reasoning is None:
         return 0
+    if (
+        spec is not None
+        and spec.reasoning_control == ReasoningControl.TOGGLE
+        and reasoning != ReasoningLevel.NONE
+    ):
+        return THINKING_HEADROOM_TOKENS[ReasoningLevel.HIGH]
     return THINKING_HEADROOM_TOKENS.get(reasoning, 0)
 
 

--- a/src/squadops/telemetry/models.py
+++ b/src/squadops/telemetry/models.py
@@ -7,6 +7,7 @@ Part of SIP-0.8.7 Infrastructure Ports Migration.
 
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
@@ -159,3 +160,45 @@ class GenerationRecord:
     # None when none was sent — so "how much did this call think" is readable
     # per generation rather than inferred from a token count.
     reasoning: str | None = None
+
+
+def build_generation_record(
+    *,
+    model: str,
+    prompt_text: str,
+    response_text: str,
+    latency_ms: float | None = None,
+    usage: Any | None = None,
+    prompt_name: str | None = None,
+    prompt_version: int | None = None,
+    reasoning: str | None = None,
+) -> GenerationRecord:
+    """Build a :class:`GenerationRecord` from a completed generation.
+
+    The construction path :class:`GenerationRecord` has named in its own docstring
+    since SIP-0061 and which never existed: five call sites hand-rolled the record
+    instead, with field sets that drifted. The planning handlers omitted all four
+    token fields, so every framing generation reached LangFuse costed at zero and
+    with no decode rate — on both arms — which is #1171. A record type that says
+    "created by the caller via build_generation_record()" should have one.
+
+    ``usage`` is any object carrying the token attributes an adapter returns
+    (``LLMResponse``, ``ChatMessage``): the four fields are read off it when it is
+    present and left ``None`` when it is not, so a caller with no usage to report
+    is expressing that rather than forgetting it. Text is capped here, at the one
+    place that knows the cap.
+    """
+    return GenerationRecord(
+        generation_id=str(uuid.uuid4()),
+        model=model,
+        prompt_text=prompt_text[:MAX_OBSERVABILITY_TEXT_LENGTH],
+        response_text=response_text[:MAX_OBSERVABILITY_TEXT_LENGTH],
+        latency_ms=latency_ms,
+        prompt_tokens=getattr(usage, "prompt_tokens", None),
+        completion_tokens=getattr(usage, "completion_tokens", None),
+        total_tokens=getattr(usage, "total_tokens", None),
+        tokens_per_second=getattr(usage, "tokens_per_second", None),
+        prompt_name=prompt_name,
+        prompt_version=prompt_version,
+        reasoning=reasoning,
+    )

--- a/src/squadops/telemetry/models.py
+++ b/src/squadops/telemetry/models.py
@@ -161,6 +161,13 @@ class GenerationRecord:
     # per generation rather than inferred from a token count.
     reasoning: str | None = None
 
+    # #1172: for a capability that retries against a validator, which attempt this
+    # was and what the validator said. A roll-up hides the repair loop, and the
+    # repair loop is the thing worth seeing — merge_plan can burn eight attempts
+    # while the record shows one task.
+    attempt: int | None = None
+    outcome: str | None = None
+
 
 def build_generation_record(
     *,
@@ -172,6 +179,8 @@ def build_generation_record(
     prompt_name: str | None = None,
     prompt_version: int | None = None,
     reasoning: str | None = None,
+    attempt: int | None = None,
+    outcome: str | None = None,
 ) -> GenerationRecord:
     """Build a :class:`GenerationRecord` from a completed generation.
 
@@ -201,4 +210,6 @@ def build_generation_record(
         prompt_name=prompt_name,
         prompt_version=prompt_version,
         reasoning=reasoning,
+        attempt=attempt,
+        outcome=outcome,
     )

--- a/tests/unit/architecture/test_generation_record_construction.py
+++ b/tests/unit/architecture/test_generation_record_construction.py
@@ -1,0 +1,49 @@
+"""Every LLM generation record is built at one seam (#1171).
+
+`GenerationRecord`'s docstring has named `build_generation_record()` as the required
+construction path since SIP-0061, but the function did not exist: five call sites
+hand-rolled the record with field sets that drifted apart. The planning handlers
+omitted all four token fields, so every framing generation reached LangFuse costed at
+zero tokens with no decode rate — on both engines — while the cycle handlers next door
+populated them. This test is the guard that a sixth handler cannot reintroduce the drift.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.domain_telemetry]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+#: The one module allowed to call the constructor: the seam itself.
+OWNER = REPO_ROOT / "src" / "squadops" / "telemetry" / "models.py"
+SEARCH_ROOTS = (REPO_ROOT / "src" / "squadops", REPO_ROOT / "adapters")
+
+
+def _direct_constructions(path: Path) -> list[int]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "GenerationRecord"
+    ]
+
+
+def test_generation_records_are_built_only_through_the_seam():
+    offenders: list[str] = []
+    for root in SEARCH_ROOTS:
+        for path in root.rglob("*.py"):
+            if path == OWNER:
+                continue
+            for line in _direct_constructions(path):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{line}")
+    assert not offenders, (
+        "GenerationRecord constructed directly instead of via build_generation_record(): "
+        + ", ".join(offenders)
+        + ". The seam exists so a call site cannot silently omit token usage (#1171)."
+    )

--- a/tests/unit/capabilities/test_plan_authoring_service.py
+++ b/tests/unit/capabilities/test_plan_authoring_service.py
@@ -801,3 +801,106 @@ async def test_unknown_profile_keeps_generic_example():
     assert "floor" not in variables["builder_guideline"]
     assert '- "qa_handoff.md"' in variables["builder_example"]
     assert '- "Dockerfile"' not in variables["builder_example"]
+
+
+# ---------------------------------------------------------------------------
+# #1172 — the manifest loop is observable
+#
+# This path had no telemetry: merge_plan called the LLM and emitted nothing, so
+# the capability that gates whether a cycle can start building was the one
+# capability LangFuse could not see. Diagnosing an Atlas failure on 2026-08-29
+# required the engine's own request dump and container logs, neither of which
+# survives a rebuild — and the same failure on the Ollama arm would have left no
+# evidence at all.
+# ---------------------------------------------------------------------------
+
+
+def _recording_context(responses: list[str]):
+    """A context whose LLM returns each seeded response in turn and whose
+    observability port captures the records it is handed."""
+    ctx = _make_context()
+    captured: list = []
+    obs = MagicMock()
+    obs.record_generation.side_effect = lambda _c, record, _l: captured.append(record)
+    ctx.ports.llm_observability = obs
+    ctx.correlation_context = MagicMock()
+    ctx.ports.llm.chat_stream_with_usage = AsyncMock(
+        side_effect=[
+            MagicMock(
+                content=body,
+                completion_tokens=100 + i,
+                prompt_tokens=900 + i,
+                total_tokens=1000 + i,
+                tokens_per_second=12.5,
+            )
+            for i, body in enumerate(responses)
+        ]
+    )
+    return ctx, captured
+
+
+async def test_every_manifest_attempt_is_recorded_with_its_verdict(seeded_inputs):
+    """One record per attempt, each carrying which attempt it was and what the
+    validator said — not a roll-up. A roll-up hides the repair loop, and the
+    repair loop is what a non-converging merge_plan consists of: eight attempts
+    behind a record that shows one task."""
+    ctx, captured = _recording_context(["no fenced block here at all", _SEEDED_LLM_RESPONSE])
+
+    artifact = await produce_plan(
+        ctx,
+        seeded_inputs,
+        planning_content="## Plan",
+        resolved_config={**seeded_inputs["resolved_config"], "manifest_max_attempts": 2},
+        role="lead",
+        handler_name="test_harness",
+        chat_kwargs={"model": "test-model", "reasoning": "high"},
+    )
+
+    assert artifact is not None, "the second attempt seeds a valid manifest"
+    assert [r.attempt for r in captured] == [1, 2], "one record per attempt, in order"
+    assert captured[0].outcome != "accepted", "the failed attempt records the rejection"
+    assert captured[1].outcome == "accepted"
+    assert captured[0].outcome, "the validator's reason is the record's outcome, not a bare flag"
+
+
+async def test_recorded_attempt_carries_usage_and_reasoning(seeded_inputs):
+    """The record is built through the seam, so token usage and the declared
+    reasoning level travel with it — the two things #1171 lost and the two that
+    make a budget-exhaustion failure legible after the fact."""
+    ctx, captured = _recording_context([_SEEDED_LLM_RESPONSE])
+
+    await produce_plan(
+        ctx,
+        seeded_inputs,
+        planning_content="## Plan",
+        resolved_config={**seeded_inputs["resolved_config"], "manifest_max_attempts": 1},
+        role="lead",
+        handler_name="test_harness",
+        chat_kwargs={"model": "test-model", "reasoning": "high"},
+    )
+
+    assert len(captured) == 1
+    record = captured[0]
+    assert record.completion_tokens == 100
+    assert record.tokens_per_second == 12.5
+    assert record.reasoning == "high"
+    assert record.model == "test-model"
+
+
+async def test_authoring_survives_a_failing_observability_port(seeded_inputs):
+    """Observability is best-effort: a recorder that raises must not fail a run
+    that produced a valid plan."""
+    ctx, _ = _recording_context([_SEEDED_LLM_RESPONSE])
+    ctx.ports.llm_observability.record_generation.side_effect = RuntimeError("langfuse down")
+
+    artifact = await produce_plan(
+        ctx,
+        seeded_inputs,
+        planning_content="## Plan",
+        resolved_config={**seeded_inputs["resolved_config"], "manifest_max_attempts": 1},
+        role="lead",
+        handler_name="test_harness",
+        chat_kwargs={},
+    )
+
+    assert artifact is not None, "a broken recorder must not lose a valid plan"

--- a/tests/unit/capabilities/test_repair_handlers.py
+++ b/tests/unit/capabilities/test_repair_handlers.py
@@ -152,14 +152,26 @@ class TestRepairEmissionClamp:
 
     def test_registry_clamp_applies_without_override(self):
         """The bug this catches: a repair on a registry-known model runs at the
-        capability ceiling instead of the model's completion clamp."""
-        from squadops.llm.model_registry import get_model_spec
+        capability ceiling instead of the model's completion clamp.
+
+        #1173 changed what the clamp is: ``default_max_completion`` budgets the
+        OUTPUT, and the thinking a capability declares is added on top, because
+        thinking is billed against the same wire budget and then discarded.
+        ``development.correction_repair`` declares MEDIUM, so the budget is the
+        output clamp plus that level's headroom — not the bare clamp."""
+        from squadops.llm.model_registry import get_model_spec, thinking_headroom
 
         h = DevelopmentRepairHandler()
         spec = get_model_spec("qwen3.8:27b")
         assert spec is not None  # premise: the V38 arm is registered (#1008)
         kwargs = h._build_chat_kwargs({"agent_model": "qwen3.8:27b", "agent_config_overrides": {}})
-        assert kwargs["max_tokens"] == spec.default_max_completion
+        assert kwargs["max_tokens"] == spec.default_max_completion + thinking_headroom(
+            kwargs.get("reasoning")
+        )
+        assert kwargs["max_tokens"] > spec.default_max_completion, (
+            "this handler declares a reasoning level, so it must get room to think "
+            "on top of its output budget"
+        )
 
     def test_explicit_override_still_wins(self):
         """A profile that deliberately raises (or lowers) the budget keeps
@@ -184,9 +196,10 @@ class TestRepairEmissionClamp:
         assert "max_tokens" not in kwargs
 
     async def test_clamp_reaches_the_llm_call(self):
-        """Flow half: the clamped budget arrives at chat_stream_with_usage —
-        wiring, not just the kwargs builder."""
-        from squadops.llm.model_registry import get_model_spec
+        """Flow half: the resolved budget arrives at chat_stream_with_usage —
+        wiring, not just the kwargs builder. Output clamp plus declared thinking
+        headroom, the two having been computed independently until #1173."""
+        from squadops.llm.model_registry import get_model_spec, thinking_headroom
 
         h = DevelopmentRepairHandler()
         ctx = _make_context(llm_response="repaired")
@@ -200,7 +213,10 @@ class TestRepairEmissionClamp:
             },
         )
         call = ctx.ports.llm.chat_stream_with_usage.call_args
-        assert call.kwargs["max_tokens"] == get_model_spec("qwen3.8:27b").default_max_completion
+        spec = get_model_spec("qwen3.8:27b")
+        assert call.kwargs["max_tokens"] == spec.default_max_completion + thinking_headroom(
+            call.kwargs.get("reasoning")
+        )
 
 
 class TestRepairHandlerHandle:

--- a/tests/unit/capabilities/test_repair_handlers.py
+++ b/tests/unit/capabilities/test_repair_handlers.py
@@ -157,8 +157,9 @@ class TestRepairEmissionClamp:
         #1173 changed what the clamp is: ``default_max_completion`` budgets the
         OUTPUT, and the thinking a capability declares is added on top, because
         thinking is billed against the same wire budget and then discarded.
-        ``development.correction_repair`` declares MEDIUM, so the budget is the
-        output clamp plus that level's headroom — not the bare clamp."""
+        ``development.correction_repair`` declares MEDIUM — but this model's dial is
+        a TOGGLE, so the level it declares and the thinking it gets are different
+        things, and the headroom is keyed on the latter."""
         from squadops.llm.model_registry import get_model_spec, thinking_headroom
 
         h = DevelopmentRepairHandler()
@@ -166,7 +167,7 @@ class TestRepairEmissionClamp:
         assert spec is not None  # premise: the V38 arm is registered (#1008)
         kwargs = h._build_chat_kwargs({"agent_model": "qwen3.8:27b", "agent_config_overrides": {}})
         assert kwargs["max_tokens"] == spec.default_max_completion + thinking_headroom(
-            kwargs.get("reasoning")
+            kwargs.get("reasoning"), spec
         )
         assert kwargs["max_tokens"] > spec.default_max_completion, (
             "this handler declares a reasoning level, so it must get room to think "
@@ -215,7 +216,7 @@ class TestRepairEmissionClamp:
         call = ctx.ports.llm.chat_stream_with_usage.call_args
         spec = get_model_spec("qwen3.8:27b")
         assert call.kwargs["max_tokens"] == spec.default_max_completion + thinking_headroom(
-            call.kwargs.get("reasoning")
+            call.kwargs.get("reasoning"), spec
         )
 
 

--- a/tests/unit/llm/test_model_registry.py
+++ b/tests/unit/llm/test_model_registry.py
@@ -155,6 +155,33 @@ class TestThinkingHeadroom:
         budget = spec.default_max_completion + thinking_headroom(ReasoningLevel.HIGH)
         assert budget >= 7_600 + 3_400
 
+    def test_a_toggle_model_budgets_every_graded_level_the_same(self):
+        """The dial decides, not the declaration. `OllamaAdapter` maps every graded
+        level onto one boolean (`think = reasoning != NONE`), so on a TOGGLE model a
+        MEDIUM capability thinks exactly as long as a HIGH one. Budgeting it by its
+        declaration under-budgets `development.develop` and both repair capabilities
+        on the production arm — the very failure #1173 was filed about."""
+        from squadops.llm.model_registry import MODEL_SPECS, ReasoningControl, thinking_headroom
+        from squadops.llm.models import ReasoningLevel
+
+        spec = MODEL_SPECS["qwen3.8:27b"]
+        assert spec.reasoning_control == ReasoningControl.TOGGLE  # premise
+        assert thinking_headroom(ReasoningLevel.MEDIUM, spec) == thinking_headroom(
+            ReasoningLevel.HIGH, spec
+        )
+        assert thinking_headroom(ReasoningLevel.MEDIUM, spec) > thinking_headroom(
+            ReasoningLevel.MEDIUM
+        ), "without the spec the declared level is read; with it, the dial is"
+
+    def test_a_toggle_model_still_spends_nothing_on_none(self):
+        """`think: false` is off, so NONE gets no headroom even on a toggle model —
+        otherwise the collapse would hand every transcription capability 6k tokens
+        it will never use."""
+        from squadops.llm.model_registry import MODEL_SPECS, thinking_headroom
+        from squadops.llm.models import ReasoningLevel
+
+        assert thinking_headroom(ReasoningLevel.NONE, MODEL_SPECS["qwen3.8:27b"]) == 0
+
     def test_an_unknown_level_does_not_invent_a_budget(self):
         """A level the table has not been told about falls back to the pre-#1173
         wire, not to a guessed allowance — the same no-masking-fallback rule the

--- a/tests/unit/llm/test_model_registry.py
+++ b/tests/unit/llm/test_model_registry.py
@@ -109,3 +109,56 @@ def test_qwen38_clamps_identically_to_the_v7_arm():
     assert spec38 is not None
     assert spec38.default_max_completion == spec36.default_max_completion == 8_192
     assert spec38.context_window == 262_144
+
+
+class TestThinkingHeadroom:
+    """#1173 — the output budget and the declared reasoning level are reconciled.
+
+    `default_max_completion` budgets OUTPUT; its basis in the registry comment is
+    wall-clock, not document size. Thinking is billed against the same wire budget
+    and then discarded by every adapter. Until #1173 the two were set independently,
+    so declaring HIGH silently shrank the answer: replaying a real merge_plan prompt
+    three times on the production arm, a complete plan needed ~3,400 output tokens
+    while thinking at HIGH cost 4,500 / 6,100 / 7,600 — one attempt in three fit.
+    """
+
+    def test_a_capability_that_does_not_think_gets_no_headroom(self):
+        """The NONE capabilities are the majority (qa.test, builder.assemble, the
+        data family): their budget must not move, or #1173 becomes a latency
+        regression across the cycle for no benefit."""
+        from squadops.llm.model_registry import thinking_headroom
+        from squadops.llm.models import ReasoningLevel
+
+        assert thinking_headroom(ReasoningLevel.NONE) == 0
+        assert thinking_headroom(None) == 0
+
+    def test_headroom_rises_with_the_declared_level(self):
+        from squadops.llm.model_registry import thinking_headroom
+        from squadops.llm.models import ReasoningLevel
+
+        assert (
+            thinking_headroom(ReasoningLevel.NONE)
+            < thinking_headroom(ReasoningLevel.LOW)
+            < thinking_headroom(ReasoningLevel.MEDIUM)
+            < thinking_headroom(ReasoningLevel.HIGH)
+        )
+
+    def test_high_covers_the_measured_worst_case(self):
+        """The number is not arbitrary: on the 27B arm a HIGH capability was
+        measured spending 7,600 thinking tokens while its document needed ~3,400.
+        Output budget plus HIGH headroom must cover that, or merge_plan keeps
+        failing for the reason #1173 was filed about."""
+        from squadops.llm.model_registry import MODEL_SPECS, thinking_headroom
+        from squadops.llm.models import ReasoningLevel
+
+        spec = MODEL_SPECS["qwen3.8:27b"]
+        budget = spec.default_max_completion + thinking_headroom(ReasoningLevel.HIGH)
+        assert budget >= 7_600 + 3_400
+
+    def test_an_unknown_level_does_not_invent_a_budget(self):
+        """A level the table has not been told about falls back to the pre-#1173
+        wire, not to a guessed allowance — the same no-masking-fallback rule the
+        provider factory follows."""
+        from squadops.llm.model_registry import thinking_headroom
+
+        assert thinking_headroom("hyper") == 0

--- a/tests/unit/telemetry/test_build_generation_record.py
+++ b/tests/unit/telemetry/test_build_generation_record.py
@@ -1,0 +1,77 @@
+"""The construction seam for generation records (#1171)."""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.telemetry.models import MAX_OBSERVABILITY_TEXT_LENGTH, build_generation_record
+
+pytestmark = [pytest.mark.domain_telemetry]
+
+
+class _Usage:
+    """The shape every adapter's response carries (LLMResponse, ChatMessage)."""
+
+    prompt_tokens = 9244
+    completion_tokens = 3401
+    total_tokens = 12645
+    tokens_per_second = 28.8
+
+
+def test_token_usage_reaches_the_record():
+    """The #1171 defect exactly: a caller with usage in hand whose record arrives at
+    LangFuse costed at zero, because the four fields were never read off it."""
+    record = build_generation_record(
+        model="qwen3.8:27b",
+        prompt_text="p",
+        response_text="r",
+        latency_ms=301_000.0,
+        usage=_Usage(),
+    )
+    assert record.prompt_tokens == 9244
+    assert record.completion_tokens == 3401
+    assert record.total_tokens == 12645
+    assert record.tokens_per_second == 28.8
+
+
+def test_absent_usage_reports_none_rather_than_zero():
+    """A caller with no usage to report must produce None, not 0 — the console chat
+    path has no response object, and a zero would be indistinguishable from a
+    generation that genuinely produced nothing."""
+    record = build_generation_record(model="m", prompt_text="p", response_text="r")
+    assert record.prompt_tokens is None
+    assert record.completion_tokens is None
+    assert record.total_tokens is None
+    assert record.tokens_per_second is None
+
+
+def test_partial_usage_takes_what_is_there():
+    """Ollama reports no reasoning_tokens and vLLM no native rate: an object missing
+    an attribute must yield None for that field, not raise."""
+
+    class _Partial:
+        completion_tokens = 512
+
+    record = build_generation_record(
+        model="m", prompt_text="p", response_text="r", usage=_Partial()
+    )
+    assert record.completion_tokens == 512
+    assert record.prompt_tokens is None
+    assert record.tokens_per_second is None
+
+
+def test_text_is_capped_at_the_seam():
+    """The cap lives here so no call site has to remember it — two of the five did not."""
+    record = build_generation_record(
+        model="m",
+        prompt_text="p" * (MAX_OBSERVABILITY_TEXT_LENGTH + 5_000),
+        response_text="r" * (MAX_OBSERVABILITY_TEXT_LENGTH + 5_000),
+    )
+    assert len(record.prompt_text) == MAX_OBSERVABILITY_TEXT_LENGTH
+    assert len(record.response_text) == MAX_OBSERVABILITY_TEXT_LENGTH
+
+
+def test_each_record_gets_its_own_id():
+    a = build_generation_record(model="m", prompt_text="p", response_text="r")
+    b = build_generation_record(model="m", prompt_text="p", response_text="r")
+    assert a.generation_id != b.generation_id


### PR DESCRIPTION
Three defects found while diagnosing why `governance.merge_plan` would not converge
(#1160). All three are engine-independent — they affect the production Ollama arm as
much as the Atlas one — and all three are in the framing half of a cycle, which is the
half the observability layer could not see.

## 1. Generation records are built at one seam — **Closes #1171**

`GenerationRecord`'s own docstring has named `build_generation_record()` as the required
construction path since SIP-0061. **The function never existed.** Five call sites
hand-rolled the record and their field sets drifted: the planning handlers omitted
`prompt_tokens`, `completion_tokens`, `total_tokens` and `tokens_per_second` entirely,
while the cycle handlers a few hundred lines away passed all four.

Measured over the 1.6.6 Next.js rolls, every generation from a planning capability —
`frame_objective`, `design_plan`, `research_context`, `define_test_strategy`,
`review_plan` — arrived at LangFuse with usage `{0,0,0}` and no decode rate, on both
engines, while `develop`, `qa.test`, `builder.assemble` and `correction_repair` were
complete. That is three of the six Atlas A/B predictions (P1, P4, P5) unreadable for
exactly the half of a cycle where the engines diverge.

The seam now exists; every site goes through it. Token fields are read off whatever
response object the caller holds, so a caller with nothing to report says so rather than
forgetting. The 10k text cap lives at the one place that knows it — two of the five sites
had not applied it. An architecture test fails the build if a sixth handler constructs a
record directly.

## 2. Every manifest attempt is a recorded generation — **Closes #1172**

`merge_plan` had no telemetry at all: `_plan_authoring_service` called the LLM and emitted
nothing. A LangFuse query across the 1.6.6 rolls returns every other capability and no
`merge_plan`, on any roll.

The cost surfaced on 2026-08-29: diagnosing a non-converging plan loop required the
inference engine's own request dump and `docker logs` on the lead agent. Neither survives
a rebuild, and the arm without a dump would have left no evidence at all. The roll
record's `framing_rerolls` counts whole framing re-rolls, not manifest attempts, so eleven
cycles recording `0` could not distinguish "landed first try" from "landed on the eighth".

One record per attempt, not a roll-up — the repair loop is the diagnostic object.
`GenerationRecord` gains `attempt` and `outcome` (the validator's own message, or
`accepted`), forwarded to LangFuse metadata. The prompt recorded is the user turn that
produced the generation, which on a repair round is the validator's complaint rather than
the original brief. Recording is best-effort: a broken port must not lose a valid plan.

## 3. The completion budget accounts for declared thinking — **Closes #1173**

`default_max_completion` budgets **output** — the registry comment records its basis as
wall-clock, not document size. But thinking is billed against the same wire budget and
every adapter discards it. `_build_chat_kwargs` computed the clamp and the reasoning level
four lines apart and never combined them, so declaring `HIGH` silently shrank the answer.

Measured on the production arm, replaying a real `merge_plan` prompt three times through
the handler's own validator:

```
thinking ~4,500 + plan ~3,400 = ~7,900   stop     ACCEPTED
thinking ~7,600 + plan   ~480 =  8,192   length   REJECTED: Missing required field: summary
thinking ~6,100 + plan ~2,000 =  8,192   length   REJECTED: Missing required field: summary
```

**One attempt in three**, hidden by a retry loop that eventually wins — at the cost of two
or three wasted five-minute generations per cycle. And it degrades with input size rather
than randomly: at the configured ceiling of 15 tasks the document alone exceeds 8,192
before the model thinks at all, so for a larger PRD `merge_plan` fails every time. Our
verification PRD is small, which is why this never surfaced.

`thinking_headroom()` adds room for the declared level on top of the output budget, at
both resolution sites. `NONE` capabilities — the majority — are unchanged. An unknown
level returns 0 rather than guessing.

**Deliberately not fixed:** reordering the plan so required fields precede `tasks`. That
would let a *truncated* plan pass validation, blinding the gate to the failure it exists
to catch.

## Tests

Full regression suite: **8,253 passed**, ruff check + format + test-quality lint clean.

New coverage: the seam's usage extraction, absent and partial usage, the text cap, id
uniqueness; an architecture test that no record is constructed outside the seam;
per-attempt recording with verdicts, usage and reasoning travelling with it, and survival
of a failing observability port; headroom monotonicity, the NONE capabilities being
unmoved, the measured worst case being covered, and an unknown level not inventing a
budget.

Two existing clamp assertions in `test_repair_handlers.py` are updated rather than
removed: they pinned the pre-#1173 contract (bare clamp), and now assert the new one
(output clamp plus declared headroom) with the rationale recorded.

Closes #1171
Closes #1172
Closes #1173

## Consequence for #1160

The rebuild on merge becomes the frozen deploy for shakeout #4. §1.5 of the A/B
pre-registration is written separately and records the 14 serve configurations, the four
inert vendor controls, and the arm-A control run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmZK2pNuaiXuzNqGrtL27h
