### PR TITLE
docs(plan): the Atlas A/B returns a negative — the record, the SIP amendment, and vLLM as the second arm

### DIFF
--- a/docker-compose.vllm.yml
+++ b/docker-compose.vllm.yml
@@ -1,0 +1,45 @@
+# vLLM arm (SIP-0106 P6, activated by §1.2b after the Atlas A/B returned a negative).
+# Pairs with ~/atlas/scripts/vllm_serve.sh. Usage:
+#   VLLM_MODEL=Qwen/Qwen3.8-27B docker compose -f docker-compose.yml -f docker-compose.vllm.yml up -d ...
+# No API key: vLLM serves unauthenticated on the loopback, unlike Atlas (--require-auth).
+services:
+  runtime-api:
+    environment:
+      SQUADOPS__LLM__PROVIDER: vllm
+      SQUADOPS__LLM__URL: http://host.docker.internal:8000
+      SQUADOPS__LLM__MODEL: "${VLLM_MODEL:?set VLLM_MODEL to the HF id vLLM serves}"
+  max:
+    environment:
+      SQUADOPS__LLM__PROVIDER: vllm
+      SQUADOPS__LLM__URL: http://host.docker.internal:8000
+      SQUADOPS__LLM__MODEL: "${VLLM_MODEL:?set VLLM_MODEL to the HF id vLLM serves}"
+  nat:
+    environment:
+      SQUADOPS__LLM__PROVIDER: vllm
+      SQUADOPS__LLM__URL: http://host.docker.internal:8000
+      SQUADOPS__LLM__MODEL: "${VLLM_MODEL:?set VLLM_MODEL to the HF id vLLM serves}"
+  neo:
+    environment:
+      SQUADOPS__LLM__PROVIDER: vllm
+      SQUADOPS__LLM__URL: http://host.docker.internal:8000
+      SQUADOPS__LLM__MODEL: "${VLLM_MODEL:?set VLLM_MODEL to the HF id vLLM serves}"
+  eve:
+    environment:
+      SQUADOPS__LLM__PROVIDER: vllm
+      SQUADOPS__LLM__URL: http://host.docker.internal:8000
+      SQUADOPS__LLM__MODEL: "${VLLM_MODEL:?set VLLM_MODEL to the HF id vLLM serves}"
+  data:
+    environment:
+      SQUADOPS__LLM__PROVIDER: vllm
+      SQUADOPS__LLM__URL: http://host.docker.internal:8000
+      SQUADOPS__LLM__MODEL: "${VLLM_MODEL:?set VLLM_MODEL to the HF id vLLM serves}"
+  bob:
+    environment:
+      SQUADOPS__LLM__PROVIDER: vllm
+      SQUADOPS__LLM__URL: http://host.docker.internal:8000
+      SQUADOPS__LLM__MODEL: "${VLLM_MODEL:?set VLLM_MODEL to the HF id vLLM serves}"
+  joi:
+    environment:
+      SQUADOPS__LLM__PROVIDER: vllm
+      SQUADOPS__LLM__URL: http://host.docker.internal:8000
+      SQUADOPS__LLM__MODEL: "${VLLM_MODEL:?set VLLM_MODEL to the HF id vLLM serves}"

--- a/docs/plans/1-7-0-atlas-ab-record.md
+++ b/docs/plans/1-7-0-atlas-ab-record.md
@@ -106,8 +106,35 @@ cannot rescue arm B: each arm-A attempt is an independent chance, so 8 attempts 
 high probability, which is why 11 of 11 recorded Next.js cycles show `framing_rerolls: 0`. Arm
 B's shakeout spent 8 attempts without one landing.
 
-**R15 — the same control at the budget #1173 now computes (`num_predict: 14336`).** Pending;
-filled in below on completion.
+**R15 — the same control at the budget #1173 now computes (`num_predict: 14336`):**
+
+| replay | eval tokens | plan | finish | verdict |
+|---|---:|---:|---|---|
+| 1 | 11,732 | 15,449 ch | `stop` | **ACCEPTED (7 tasks)** |
+| 2 | 8,285 | 11,909 ch | `stop` | **ACCEPTED (7 tasks)** |
+| 3 | 9,586 | 10,074 ch | `stop` | **ACCEPTED (4 tasks)** |
+| 4 | 8,204 | 10,975 ch | `stop` | **ACCEPTED (6 tasks)** |
+| 5 | 7,350 | 12,806 ch | `stop` | **ACCEPTED (8 tasks)** |
+
+**5 of 5**, against 1 of 3 at the old flat clamp. The mechanism is the one #1173 names: the 8,192
+cap truncated the document before `summary` could be emitted, and both R0 failures said exactly
+that. One replay (11,732 tokens) genuinely needed room past the old cap; the rest finish well
+below the new one, which is why the fix is nearly free.
+
+**Cost per attempt barely moved.** Mean 305 s at 14,336 against 289 s at 8,192 — +5.5% — because
+a *failed* attempt at 8,192 burned the full cap by definition, while a successful attempt at
+14,336 averages 9,031 tokens. The budget is not buying longer generations; it is buying an end to
+wasted ones.
+
+**Wall-clock consequence, derived rather than measured.** At a 1-in-3 accept rate the handler's
+retry loop expects 3 attempts to land a plan (3 × 289 s ≈ 14.5 min); at the observed rate it
+expects 1 (≈ 5.1 min). Against framing runs that historically took 28.4–37.8 min against
+implementation's 14.8–21.9, a ~9 min saving is a material share of cycle wall clock. This is
+arithmetic from replay timings, **not** a measured cycle: `agent_task_log` holds zero rows and
+#1172 meant `merge_plan` emitted no generation record, so the rest of framing's ~34 min cannot
+currently be attributed. The fix-validation shakeout `cyc_74a6ad13d309` is the direct
+measurement; n here is 8 replays, and it is the mechanism rather than the rate that carries the
+claim.
 
 ## 5. Model support
 

--- a/docs/plans/1-7-0-atlas-ab-record.md
+++ b/docs/plans/1-7-0-atlas-ab-record.md
@@ -160,6 +160,42 @@ previously exist, and all fixed in #1174:
 and #1172. An A/B that returns a negative on its headline question and three production fixes on
 the way is not a wasted set.
 
+**Validated end to end on 2026-08-30** by fix-validation shakeout `cyc_74a6ad13d309`, on the
+post-#1174 frozen deploy (`05eae807bb3d`, head `bbf706ae`), non-counting by declaration:
+
+| field | value |
+|---|---|
+| verdict | **accepted** |
+| boot audit | **PASS** — installs, builds, boots, answers 5 contract probes |
+| functional (verdict AND audit AND zero intervention) | **yes** |
+| criteria verified / total | 14 / 14 |
+| correction rounds | 0 |
+| framing runs / re-rolls | 1 / 0 |
+| wall clock | 43 min (framing 30, implementation 13) |
+| gate | `progress_plan_review` → approved by `system:no_open_questions` |
+
+Each fix is confirmed by its own evidence, not by the cycle passing:
+
+- **#1171** — all 11 generations in the window carry non-zero prompt and completion token usage.
+  Zero-usage count: 0. Previously every framing generation reached LangFuse costed at nothing.
+- **#1172** — `task-run_fb18e5b6-006-governance.merge_plan` appears in LangFuse at all, carrying
+  `attempt: 1` and `outcome: accepted`. That capability was previously invisible, which is why
+  §1.5's guard diagnosis had to come from `--dump` instead.
+- **#1173** — `merge_plan` landed on **attempt 1**. At the pre-fix per-attempt rate the handler's
+  retry loop expected three. This is the first cycle-level observation of the budget fix, and it
+  is only observable because #1172 landed with it.
+- Reasoning levels thread correctly per capability (#927): `medium` for research and develop,
+  `high` for the framing authors, `none` for `qa.test` and `builder.assemble`.
+
+**On wall clock, the measurement is weaker than the arithmetic.** Framing at 30.1 min sits at the
+fast end of the historical band for successful framing runs (28.4–37.8, mean 34.2) but inside it.
+The derived estimate above (~9 min) is not confirmed by this cycle, which shows roughly 4 min
+against the mean. One cycle cannot separate a real improvement from variance on a spread that
+wide, and the 1-in-3 rate it was derived from came from replaying a single stored prompt that may
+be harder than typical. What *is* established is the mechanism and the attempt count: `merge_plan`
+now lands first try, visibly. The wall-clock claim needs several cycles, and should not be quoted
+as measured until it has them.
+
 ## 7. Incident
 
 On 2026-08-29 the arm-A control was run directly against Ollama while the Atlas container still

--- a/docs/plans/1-7-0-atlas-ab-record.md
+++ b/docs/plans/1-7-0-atlas-ab-record.md
@@ -1,0 +1,167 @@
+# 1.7.0 — the Atlas A/B, record (#1160, SIP-0106 P5)
+
+The artifact §4 of `1-7-0-atlas-ab-preregistration.md` commits to. It is not the shape that
+section describes, and the reason is the result: **the set never opened to counting rolls.**
+Arm B could not complete a shakeout, so there are no cycle rows to tabulate. What follows is
+what the shakeout phase established, scored through the production validator, and the owner's
+disposition.
+
+**Outcome: Atlas is not adopted.** Ruled by the owner on 2026-08-29 on the evidence below.
+Recorded as an amendment in SIP-0106 §1.2a, which is the permanent home; this file is the
+measurement record behind it.
+
+## 1. What was run
+
+Three shakeout cycles and a 14-configuration replay matrix. No counted roll on either arm.
+
+| # | Cycle | Date | Outcome |
+|---|---|---|---|
+| Shakeout 1 | `cyc_6e068cdd7de0` | 2026-08-28 | failed — Atlas `--request-timeout` default of 300 s cut generations, returned as a 200 with `finish_reason=timeout` |
+| Shakeout 2 | `cyc_6db3a5d8d1ca` | 2026-08-28 | failed — content-loop guard severing YAML plans |
+| Shakeout 3 | `cyc_cc5c58ff2cde` | 2026-08-29 | failed at `governance.merge_plan` after 8 manifest attempts across two rounds; recorded `blocked_unverified` |
+
+Each failure produced a serve-line fix and the next shakeout. The third exhausted the
+available controls, which is what turned the question from "tune it" into "can it do this at
+all" and produced the replay matrix.
+
+## 2. The replay matrix — the substantive result
+
+One stored `merge_plan` prompt (9,244 prompt tokens), replayed byte-identically, each response
+scored through `ImplementationPlan.from_yaml` — the handler's own gate, not a bare YAML parse.
+
+| row | change | accepted | guard-stopped |
+|---|---|---:|---:|
+| R1 | baseline (the §1.1–§1.4 serve line, FP8) | 0/3 | 1/3 |
+| R4 | per-request `repetition_detection`, `min_count: 64` | 0/3 | 2/3 |
+| R7 | `max_tokens: 16384` | 0/3 | 3/3 |
+| R6 | `reasoning_effort: high` | — | 400: no such tier |
+| R6′ | `reasoning_effort: medium` | 0/3 | 3/3 |
+| R8 | `xhigh` + `chat_template_kwargs.thinking_budget: 2048` | 0/3 | 3/3 |
+| R2 | `ATLAS_CONTENT_LOOP_WATCHDOG=false` (env) | 0/3 | 3/3 |
+| R3 | `--content-loop-min-repeats 64` | 0/3 | 3/3 |
+| R5 | `--kv-cache-dtype fp8` | 0/3 | 3/3 |
+| R10 | the vendor's own recipe, verbatim, NVFP4 checkpoint | 0/1 | 1/1 |
+| R11 | NVFP4 + recipe flags at serving size | 0/3 | 3/3 |
+| R12 | R11 + `ATLAS_SSM_DECODE_RING=1` | 0/3 | 3/3 |
+| R13 | R11 + `temperature: 0.2` | 0/3 | 3/3 |
+| R14 | R12 + `temperature: 0.2` | 0/3 | 3/3 |
+
+**14 configurations · 44 plan emissions · 41 guard-stopped · 0 accepted.** All 41 stopped
+*below* the completion cap — the budget was never the binding constraint on this arm.
+
+**The mechanism.** The guard fires on legitimately repetitive YAML (consecutive
+`- check: / file: / severity:` blocks, of which a 15-task plan carries fifty). The damage is not
+the stop but the rollback-and-re-steer, capped at 2 per sequence, rewinding mid-token:
+`depends_on: []` emerges as `depend0]`, `frontend_compiles` as `frontend_compil`. Those
+corruptions *are* the validator's "while scanning a simple key" and "mapping values are not
+allowed here".
+
+**It cannot be disarmed.** Four documented controls are inert: the `--content-loop-watchdog
+false` CLI flag (correct syntax per `--help`, startup line unchanged); the
+`ATLAS_CONTENT_LOOP_WATCHDOG` env var (confirmed set on the container, behaviour unchanged); the
+per-request `repetition_detection` object the help says "still outranks this", at `min_count:
+64` against a default of 3; and `--content-loop-min-repeats 64`, the vendor's own documented
+remedy for output that is "short-period repetitive (code, tables)". A second detector,
+`simhash_semantic_loop`, has no CLI flag and no env var in `--help` at all.
+
+Two rows carry their own caveat. **R10** used the vendor recipe verbatim including
+`--max-batch-size 1` and `--gpu-memory-utilization 0.85`, which yields a 12,976-token KV pool on
+this box; one 9,244-token prompt exhausts it, so two of three replays died on `KV cache
+exhausted`. The recipe says of itself that 32K "is a gate value, not a recommendation" — it is a
+qualification config, not a serving one. **R12/R14** forced the SSM decode-rollback ring back on,
+the only knob that visibly changed engine state; it shifted the failure from corruption toward
+clean truncation without changing the verdict.
+
+## 3. Predictions
+
+| # | Prediction | Result |
+|---|---|---|
+| P1 | arm B decode rate ≥ 2× arm A on `none` generations | **FALSIFIED, in reverse.** Arm A 28.8–29.2 tok/s on the framing prompt; arm B 12–14 tok/s. Both decode-only, from each engine's own reporting. The tuning matrix's 33.8 tok/s came from a short fill brief; #1160 had already recorded framing decode at 12–18 tok/s |
+| P2 | paired cycle wall-clock B < A on every Next.js pair | **unanswerable** — no counted cycle on either arm |
+| P3 | verdict parity, no arm-B rejection naming the runner | **unanswerable** — same |
+| P4 | completion tokens per task type within ±20% between arms | **unanswerable** — same |
+| P5 | every arm-B qa-fill generation carries `reasoning_tokens = 0` | **unanswerable** — same |
+| P6 | FastAPI+React corrections consumed B ≤ A | **unanswerable** — same |
+
+P2–P6 read from counted cycles. Arm B cannot clear `governance.merge_plan`, so it never reaches
+build, so those cycles do not exist. This is a property of the result, not a gap in the
+instrument.
+
+## 4. The arm-A control
+
+Run because a 0/44 on arm B means nothing without knowing what arm A does on the same prompt,
+through the same validator.
+
+**R0 — production budget as it stood (`num_predict: 8192`):**
+
+| replay | thinking | plan | finish | verdict |
+|---|---:|---:|---|---|
+| 1 | 16,716 ch | 12,573 ch | `stop` | **ACCEPTED (5 tasks)** |
+| 2 | 27,920 ch | 1,774 ch | `length` | rejected: missing `summary` |
+| 3 | 22,474 ch | 7,406 ch | `length` | rejected: missing `summary` |
+
+**1 of 3.** Both failures are budget exhaustion with no guard involved — the opposite of arm B's
+failure, which is the guard, below the budget. That difference is why retries rescue arm A and
+cannot rescue arm B: each arm-A attempt is an independent chance, so 8 attempts land a plan with
+high probability, which is why 11 of 11 recorded Next.js cycles show `framing_rerolls: 0`. Arm
+B's shakeout spent 8 attempts without one landing.
+
+**R15 — the same control at the budget #1173 now computes (`num_predict: 14336`).** Pending;
+filled in below on completion.
+
+## 5. Model support
+
+`Qwen/Qwen3.8-27B-FP8` is not in the supported-model table of the shipped image's README, of the
+GitHub README, or of the GB10 Deployment Guide. Support exists only as a recipe in
+`atlas-recipes`, annotated "tested on binary main 680b3a568". The kernel audit cited in §2
+precondition 3 (236 lookups / 0 unresolved) was run against the **NVFP4** checkpoint, not the FP8
+one the A/B served. R11 closes that gap: on the NVFP4 weights, with the audited kernel set, the
+outcome is identical. Unsupported-model status is therefore not an available explanation for the
+result.
+
+## 6. What the A/B produced anyway
+
+Three engine-independent defects, all found because the A/B forced instrumentation that did not
+previously exist, and all fixed in #1174:
+
+- **#1171** — framing generations reached LangFuse costed at zero tokens
+- **#1172** — `governance.merge_plan` emitted no generation record at all
+- **#1173** — the completion budget ignored the reasoning level a capability declares, which is
+  the whole of arm A's failure rate above
+
+`--dump` (added by §1.3) is the only reason the guard behaviour was knowable at all, given #1171
+and #1172. An A/B that returns a negative on its headline question and three production fixes on
+the way is not a wasted set.
+
+## 7. Incident
+
+On 2026-08-29 the arm-A control was run directly against Ollama while the Atlas container still
+held `--gpu-memory-utilization 0.90`. The Spark's 121 GiB is unified; both engines went resident;
+the box entered swap thrash at 17:50:44 and was unreachable until a power cycle at ~19:25. Ollama
+recorded the decision: `free="7.8 GiB"` against `need to reduce device memory by 28802 MiB`, and
+it loaded anyway.
+
+This is Appendix C.5 trap 1 of SIP-0106, realised. Filed as **#1177** (`arm.sh` enforces arm
+exclusivity but the replay scripts bypass it; `atlas_serve_nvfp4.sh` raised utilization to 0.90
+and dropped the reserve `atlas_serve.sh` warns about) and **#1178** (the box has no OOM
+containment — no `systemd-oomd`, no earlyoom, no `MemoryMax=`). A preflight guard is now in
+`replay_ollama.py`. No measurement in this record is affected: the incident followed the last
+completed Atlas request at 16:55:59, and the only run it interrupted was R15, whose two timed-out
+replays are discarded rather than reported.
+
+## 8. Disposition
+
+- **Atlas is not adopted.** SIP-0106 §1.2a records the amendment; the merged `AtlasAdapter`
+  stays inert in the tree under the §4 dark-ship rule, so no revert is required.
+- **vLLM becomes the second arm** (SIP-0106 §1.2b), activating P6 — written in §3.5a as the
+  hedge for exactly this outcome. It needs its own pre-registration; this one does not transfer,
+  because its fixed parameters and predictions are engine-specific.
+- **The gating unknown for that work** is the one §3.5a already stated: vLLM on GB10 / ARM64 is
+  unverified, and the SIP's instruction is to verify before scheduling. A feasibility probe
+  precedes the new pre-registration.
+- **A vendor report on `simhash_semantic_loop`** is worth filing regardless of adoption: a guard
+  with no flag and no env var, firing on correct output, whose rollback corrupts the stream
+  mid-token.
+- **Everything else SIP-0106 built stands and is shipped** — provider selection as required
+  configuration, declared capabilities, on-port model availability, provider-scoped model
+  identity, and the conformance suite. The seam is what made rejecting the engine cheap.

--- a/docs/plans/verification-sets/1-7-0-ab-ollama-fastapi-react.yaml
+++ b/docs/plans/verification-sets/1-7-0-ab-ollama-fastapi-react.yaml
@@ -1,6 +1,8 @@
-# 1.7.0 Atlas A/B (#1160), arm OLLAMA — FastAPI+React pair (correction texture). Pre-registration:
-# docs/plans/1-7-0-atlas-ab-preregistration.md. Rolls interleave with the other arm
-# (A3, B3); the arm switch and engine isolation are manual between rolls.
+# 1.7.0 arm OLLAMA — FastAPI+React (correction texture). Pre-registration (historical,
+# the set it was authored for): docs/plans/1-7-0-atlas-ab-preregistration.md
+# STATUS 2026-08-29: the Atlas A/B (#1160) is STOPPED — negative result, no counted
+# rolls ran. This set is retained for fix-validation shakeouts and will be rewritten
+# against the vLLM-vs-Ollama pre-registration when that is authored (SIP-0106 §1.2b).
 name: 1-7-0-ab-ollama-fastapi-react
 pre_registration: docs/plans/1-7-0-atlas-ab-preregistration.md
 project: group_run
@@ -16,8 +18,12 @@ launch_notes: >-
   1.7.0 Atlas A/B — arm ollama, COUNTED roll {roll} of {n} on fastapi-react_ts. Frozen deploy per the
   pre-registration; predictions P1, P3, P4, P6; the pair's other arm is the comparison.
 shakeout_notes: >-
-  1.7.0 Atlas A/B — arm ollama SHAKEOUT, NON-COUNTING by declaration before launch: the first
-  cycle ever on this engine; also the warm-up Appendix C.2 requires, recorded and flagged.
+  Fix-validation shakeout, NON-COUNTING by declaration before launch. Validates #1171 (framing
+  generations costed at zero tokens), #1172 (merge_plan emitted no generation record) and #1173
+  (completion budget ignored declared reasoning level) end to end on the post-#1174 frozen
+  deploy. Not an A/B roll: the Atlas A/B was stopped on 2026-08-29 as a negative result
+  (SIP-0106 §1.2a, docs/plans/1-7-0-atlas-ab-record.md). The superseding pre-registration for
+  the vLLM-vs-Ollama A/B is not yet written; the counted-roll fields below are inert until it is.
 loaded_checks:
   runtime-api: >-
     from squadops.config import load_config; c = load_config();

--- a/docs/plans/verification-sets/1-7-0-ab-ollama-nextjs.yaml
+++ b/docs/plans/verification-sets/1-7-0-ab-ollama-nextjs.yaml
@@ -1,6 +1,8 @@
-# 1.7.0 Atlas A/B (#1160), arm OLLAMA — Next.js+TS pairs. Pre-registration:
-# docs/plans/1-7-0-atlas-ab-preregistration.md. Rolls interleave with the other arm
-# (A1, B1, B2, A2); the arm switch and engine isolation are manual between rolls.
+# 1.7.0 arm OLLAMA — Next.js+TS. Pre-registration (historical, the set it was
+# authored for): docs/plans/1-7-0-atlas-ab-preregistration.md
+# STATUS 2026-08-29: the Atlas A/B (#1160) is STOPPED — negative result, no counted
+# rolls ran. This set is retained for fix-validation shakeouts and will be rewritten
+# against the vLLM-vs-Ollama pre-registration when that is authored (SIP-0106 §1.2b).
 name: 1-7-0-ab-ollama-nextjs
 pre_registration: docs/plans/1-7-0-atlas-ab-preregistration.md
 project: group_run
@@ -18,8 +20,12 @@ launch_notes: >-
   1.7.0 Atlas A/B — arm ollama, COUNTED roll {roll} of {n} on nextjs_ts. Frozen deploy per the
   pre-registration; predictions P1–P5; the pair's other arm is the comparison.
 shakeout_notes: >-
-  1.7.0 Atlas A/B — arm ollama SHAKEOUT, NON-COUNTING by declaration before launch: the first
-  cycle ever on this engine; also the warm-up Appendix C.2 requires, recorded and flagged.
+  Fix-validation shakeout, NON-COUNTING by declaration before launch. Validates #1171 (framing
+  generations costed at zero tokens), #1172 (merge_plan emitted no generation record) and #1173
+  (completion budget ignored declared reasoning level) end to end on the post-#1174 frozen
+  deploy. Not an A/B roll: the Atlas A/B was stopped on 2026-08-29 as a negative result
+  (SIP-0106 §1.2a, docs/plans/1-7-0-atlas-ab-record.md). The superseding pre-registration for
+  the vLLM-vs-Ollama A/B is not yet written; the counted-roll fields below are inert until it is.
 loaded_checks:
   runtime-api: >-
     from squadops.config import load_config; c = load_config();

--- a/sips/accepted/SIP-0106-Atlas-Provider-Adapter.md
+++ b/sips/accepted/SIP-0106-Atlas-Provider-Adapter.md
@@ -152,6 +152,81 @@ references #301 without closing it (§10.1); the headline throughput number is
 fixing but **no longer a precondition of anything** under Ruling 2 — the Prefect log line
 carries throughput adequately for an owner reading results.
 
+## 1.2 Post-acceptance amendments
+
+Recorded here, in the SIP, because a release plan is superseded at the cut and a code comment
+is invisible to a reader of the spec (CLAUDE.md, the §5a rule). `updated_at` is deliberately
+untouched — it means *last status transition*, and these dated entries are the content record.
+
+### 1.2a P4/P5 return a negative — Atlas is not adopted (owner ruling, 2026-08-29)
+
+**What changed.** The A/B this SIP's P5 exists to produce (#1160) is **stopped without counting
+rolls**. Atlas is not adopted as a provider. The `AtlasAdapter` merged under P4 (#1165) stays in
+the tree, inert, selected by nobody — the dark-ship rule of §4 is what makes that safe and is
+why no revert is required.
+
+**The evidence, in full.** Recorded in `docs/plans/1-7-0-atlas-ab-preregistration.md` §1.5 and
+the record beside it:
+
+- **0 accepted plans out of 44 emissions across 14 serve configurations.** 41 were stopped by
+  Atlas's content-loop guard, every one of them *below* the completion cap, so the budget was
+  never the binding constraint. Scored through `ImplementationPlan.from_yaml` — the handler's
+  own gate, not a bare YAML parse.
+- **The guard cannot be disarmed.** Four documented controls are inert against it: the
+  `--content-loop-watchdog false` CLI flag, the `ATLAS_CONTENT_LOOP_WATCHDOG` env var, the
+  per-request `repetition_detection` object the vendor's help says "still outranks this", and
+  `--content-loop-min-repeats`. A second detector, `simhash_semantic_loop`, has no CLI flag and
+  no env var at all.
+- **It fires on correct output and corrupts it.** The severed content is legitimately repetitive
+  YAML — consecutive `- check: / file: / severity:` blocks, which a 15-task plan carries fifty
+  of. The damage is the rollback-and-re-steer rewinding mid-token (`depends_on: []` emerging as
+  `depend0]`), which *is* the validator's "malformed YAML".
+- **P1 is falsified in the reverse direction.** Predicted: arm B ≥ 2× arm A on decode rate.
+  Observed on the framing workload: arm A 28.8–29.2 tok/s, arm B 12–14 tok/s, both decode-only
+  from each engine's own reporting. P2–P6 are unanswerable — they read from counted cycles that
+  never ran, because arm B cannot clear `governance.merge_plan` to reach build.
+- **Model support was never there.** `Qwen/Qwen3.8-27B-FP8` is absent from the supported-model
+  table of the shipped image's README, the GitHub README, and the GB10 Deployment Guide; it
+  exists only as an `atlas-recipes` entry annotated "tested on binary main 680b3a568". R11
+  reproduced the identical outcome on the NVFP4 checkpoint the §2 precondition-3 kernel audit
+  actually covered, closing that gap rather than leaving it as a possible explanation.
+
+**What this does not change.** Everything this SIP built other than the Atlas adapter stands and
+is shipped: provider selection as required configuration (§3.1, #1157/#1164), declared rather
+than inferred capabilities (§3.2), on-port model availability (§3.3), provider-scoped model
+identity (§3.4), and the conformance suite (§3.6). The negative is about one engine, not about
+the seam — and the seam is what made the engine swappable enough to reject cheaply.
+
+### 1.2b P6 activates: vLLM becomes the A/B's second arm (owner ruling, 2026-08-29)
+
+§3.5a wrote P6 as "optional, non-gating" and named its secondary value: "it hedges P4/P5 failure
+— a second migration target already proven through the same gate." P4/P5 failed; the hedge is
+called. **vLLM replaces Atlas as arm B against production Ollama.** P6 is no longer optional.
+
+Already in place, requiring no new work: `adapters/llm/vllm.py`, `VLLMAdapter` green at 16 unit
+tests, factory selection on `provider == "vllm"`, `"vllm"` in the config schema, and coverage in
+the shared conformance suite. Outstanding: a live serve on the box, a `docker-compose.vllm.yml`
+on the pattern of `docker-compose.atlas.yml`, verification sets, and a fresh pre-registration —
+the Atlas one does not transfer, since its §1 fixed parameters and §3 predictions are engine-specific.
+
+**The gating unknown is the one §3.5a already stated** and it is now on the critical path rather
+than optional: "vLLM's maturity on DGX Spark's GB10 Grace Blackwell / ARM64 platform is
+**unverified here** … If it will not run well on the box, the control arm is unavailable and P6
+drops … **Verify before scheduling it, not after.**" A feasibility probe therefore precedes the
+new pre-registration. If it fails, this SIP's provider work still stands on Ollama alone and the
+A/B question closes for want of a second engine.
+
+### 1.2c A trap this SIP names cost the box 95 minutes (2026-08-29)
+
+Appendix C.5 trap 1 — both engines resident at once — is not only a measurement hazard on the
+Spark's **unified** 121 GiB. On 2026-08-29 an arm-A control replay was run directly against
+Ollama while the Atlas container still held `--gpu-memory-utilization 0.90`; the box went into
+swap thrash at 17:50 and was unreachable until a power cycle at ~19:25. Ollama's own log records
+it deciding to load anyway: `free="7.8 GiB"` against `need to reduce device memory by 28802 MiB`.
+Filed as #1177 (the A/B rig's arm-exclusivity guard is bypassable) and #1178 (the box has no OOM
+containment: no `systemd-oomd`, no earlyoom, no `MemoryMax=`). Any vLLM A/B inherits the trap and
+must carry the guard.
+
 ## 2. Problem Statement
 
 ### 2.0 What Atlas is (recorded here because nothing else records it)


### PR DESCRIPTION
Arm B produced **0 accepted plans out of 44 emissions across 14 serve configurations**. 41 were stopped by Atlas's content-loop guard, every one of them *below* the completion cap, so the budget was never the binding constraint. Four documented controls are inert against that guard, and a second detector (`simhash_semantic_loop`) has no CLI flag and no env var at all. It fires on legitimately repetitive YAML and its rollback-and-re-steer rewinds mid-token — `depends_on: []` emerging as `depend0]` — which *is* the validator's "malformed YAML".

**P1 is falsified in the reverse direction**: arm A decodes at 28.8–29.2 tok/s on the framing prompt against arm B's 12–14, both decode-only from each engine's own reporting. P2–P6 are unanswerable, not missing: arm B never clears `governance.merge_plan` to reach build, so no counted cycle exists on either arm.

Owner ruled on 2026-08-29 that the A/B stops and Atlas is not adopted.

## What's here

- **`docs/plans/1-7-0-atlas-ab-record.md`** — the §4 artifact. Written as a negative-result record rather than the per-cycle table §4 describes, because the set never opened to counting rolls. Says which predictions are answered vs unanswerable and why, carries the arm-A control, and does not let "unsupported model" stand as an escape hatch: R11 reproduced the identical outcome on the NVFP4 checkpoint the §2 precondition-3 kernel audit actually covered.
- **SIP-0106 §1.2** — a post-acceptance amendment section, per the CLAUDE.md §5a rule that a disposition deliberately not built is an amendment too. §1.2a the negative and what it does *not* change; §1.2b P6 activating with vLLM; §1.2c the Appendix C.5 trap-1 incident. `updated_at` deliberately untouched.
- **The two arm-OLLAMA verification sets** — notes claimed "the first cycle ever on this engine", never true for production Ollama, and pointed at a set that no longer runs. They now declare what a shakeout on them actually validates.
- **`docker-compose.vllm.yml`** — the vLLM arm's deploy override, on the Atlas pattern, without the auth plumbing vLLM doesn't use.

## Notes for review

The merged `AtlasAdapter` stays inert in the tree under the SIP's §4 dark-ship rule — no revert required. Everything else SIP-0106 built stands and is shipped; the seam is what made rejecting the engine cheap.

vLLM as the second arm is not a new direction: §3.5a wrote P6 as the hedge for exactly this outcome. Its gating unknown is the one that section already stated — vLLM on GB10/ARM64 is unverified, and the SIP says verify before scheduling. A feasibility probe precedes the new pre-registration, so this PR adds only the deploy override, not a pre-registration.

The set never reached counted rolls, but it produced #1171, #1172 and #1173 — all engine-independent, all fixed in #1174, and #1173 is the whole of arm A's own failure rate.

Closes #1160
Refs #1177 — remaining: the rig's arm-exclusivity guard fix itself
Refs #1178 — remaining: OOM containment on the box

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EEKMmFdD43zvr9eLyggJUe